### PR TITLE
Add Server to the config, and pull it into the payload data if it is set

### DIFF
--- a/Rollbar/Rollbar.cs
+++ b/Rollbar/Rollbar.cs
@@ -53,6 +53,10 @@ namespace RollbarDotNet
             payload.Data.GuidUuid = guid;
             payload.Data.Person = _personFunc?.Invoke();
 
+            if (_config.Server != null) {
+              payload.Data.Server = _config.Server;
+            }
+
             _config.Transform?.Invoke(payload);
             client.PostItem(payload);
 

--- a/Rollbar/RollbarConfig.cs
+++ b/Rollbar/RollbarConfig.cs
@@ -31,5 +31,7 @@ namespace RollbarDotNet
         public string Environment { get; set; }
 
         public Action<Payload> Transform { get; set; }
+
+        public Server? Server { get; set; }
     }
 }


### PR DESCRIPTION
According to this page: https://rollbar.com/docs/github/

In order to let our servers know that you want it to try linking your stack trace to the files on GitHub you should send the "server.root" key. A lot of the time that can be "/", to indicate that all files can be linked to a file in GitHub.

There was already a Server type which is wired up to be sent with the payload data if it is set, but there was no easy way to set this value. One way would be to use the transform to modify the data in the payload similar to how the person field is set in the docs. That is a bit hacky. This PR adds the Server type to the config so that it is more of a first class citizen which gets added as necessary.