### PR TITLE
Fix #52: use HttpClient class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,6 @@ FakesAssemblies/
 
 # Visual Studio 6 workspace options file
 *.opt
+
+# JetBrains IDE
+.idea

--- a/Rollbar/Rollbar.csproj
+++ b/Rollbar/Rollbar.csproj
@@ -1,5 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <AssemblyName>Rollbar</AssemblyName>
@@ -16,9 +15,12 @@
     <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/rollbar/Rollbar.NET/master/rollbar-logo.png</PackageIconUrl>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
-
+  <ItemGroup>
+    <Reference Include="System.Net.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\..\..\..\..\Library\Frameworks\Mono.framework\Versions\5.4.0\lib\mono\4.5-api\System.Net.Http.dll</HintPath>
+    </Reference>
+  </ItemGroup>
 </Project>

--- a/Samples/ConsoleApp/ConsoleApp/ConsoleApp.csproj
+++ b/Samples/ConsoleApp/ConsoleApp/ConsoleApp.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>RollbarDotNet.Samples.ConsoleApp</RootNamespace>
     <AssemblyName>ConsoleApp</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />


### PR DESCRIPTION
Changed implementation from WebClient to HttpClient, as discussed in #52. I’ve refrained myself from refactoring other stuff. 

Other commits are small chores and cleanups and should be non-breaking, with the exception that the sample ConsoleApp now targets .NET 4.5.2 (instead of 4.5).

Thought this would be an easy fix, so just went ahead and made this PR. Hope this helps!