### PR TITLE
ref #71: Implement a Blocking/Synchronous Error Reporting Method

### DIFF
--- a/Rollbar.sln
+++ b/Rollbar.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+VisualStudioVersion = 15.0.27130.2027
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionItems", "{3635FA93-6994-4CE4-9923-BF330DF1A439}"
 	ProjectSection(SolutionItems) = preProject
@@ -20,6 +20,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitTest.Rollbar", "UnitTest.Rollbar\UnitTest.Rollbar.csproj", "{E5A3554A-D1AE-4D3A-9677-C6D586501CE2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.WebForms.Site", "Sample.WebForms.Site\Sample.WebForms.Site.csproj", "{B5680C23-FC2C-4408-9885-4282CCADCCE1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.Net.ConsoleApp", "Sample.Net.ConsoleApp\Sample.Net.ConsoleApp.csproj", "{B75EB341-10CC-4C91-9F8E-C6EFA3817F57}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -47,6 +49,10 @@ Global
 		{B5680C23-FC2C-4408-9885-4282CCADCCE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B5680C23-FC2C-4408-9885-4282CCADCCE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B5680C23-FC2C-4408-9885-4282CCADCCE1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B75EB341-10CC-4C91-9F8E-C6EFA3817F57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B75EB341-10CC-4C91-9F8E-C6EFA3817F57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B75EB341-10CC-4C91-9F8E-C6EFA3817F57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B75EB341-10CC-4C91-9F8E-C6EFA3817F57}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -55,6 +61,7 @@ Global
 		{03F99D21-9190-4FD3-BC1C-DFF271257F9D} = {F384356A-AB7F-4CC6-A870-BFB0738F973A}
 		{413CA41B-B9F2-41FD-B705-34EB38B2DB76} = {F384356A-AB7F-4CC6-A870-BFB0738F973A}
 		{B5680C23-FC2C-4408-9885-4282CCADCCE1} = {F384356A-AB7F-4CC6-A870-BFB0738F973A}
+		{B75EB341-10CC-4C91-9F8E-C6EFA3817F57} = {F384356A-AB7F-4CC6-A870-BFB0738F973A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AB9E5CFE-0437-4312-99E5-1EBF60FB8157}

--- a/Rollbar/DTOs/Payload.cs
+++ b/Rollbar/DTOs/Payload.cs
@@ -2,6 +2,8 @@
 {
     using Newtonsoft.Json;
     using Rollbar.Diagnostics;
+    using System;
+    using System.Threading;
 
     /// <summary>
     /// Models Rollbar Payload DTO.
@@ -10,13 +12,38 @@
     public class Payload
         : DtoBase
     {
+        private readonly DateTime? _timeoutAt = null;
+        private readonly SemaphoreSlim _signal = null;
+
+        [JsonIgnore]
+        internal DateTime? TimeoutAt
+        {
+            get { return this._timeoutAt; }
+        }
+
+        [JsonIgnore]
+        internal SemaphoreSlim Signal
+        {
+            get { return this._signal; }
+        }
+
         /// <summary>
-        /// Initializes a new instance of the <see cref="Payload"/> class.
+        /// Initializes a new instance of the <see cref="Payload" /> class.
         /// </summary>
         /// <param name="accessToken">The access token.</param>
         /// <param name="data">The data.</param>
-        public Payload(string accessToken, Data data)
+        /// <param name="timeoutAt">The timeout at.</param>
+        /// <param name="signal">The signal.</param>
+        public Payload(
+            string accessToken, 
+            Data data, 
+            DateTime? timeoutAt = null,
+            SemaphoreSlim signal = null
+            )
         {
+            this._timeoutAt = timeoutAt;
+            this._signal = signal;
+
             AccessToken = accessToken;
             Data = data;
             Validate();

--- a/Rollbar/DTOs/_DTOs.cd
+++ b/Rollbar/DTOs/_DTOs.cd
@@ -1,107 +1,135 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ClassDiagram MajorVersion="1" MinorVersion="1">
-  <Class Name="Rollbar.DTOs.Body" Collapsed="true">
-    <Position X="5.25" Y="3.25" Width="1.5" />
+  <Class Name="Rollbar.DTOs.Body">
+    <Position X="10" Y="2.75" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAACAAAAAAAAAAAAAAAAAABAAAAIIIAAAAAA=</HashCode>
       <FileName>DTOs\Body.cs</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Rollbar.DTOs.Client" Collapsed="true">
-    <Position X="1.25" Y="4.5" Width="1.5" />
+  <Class Name="Rollbar.DTOs.Client">
+    <Position X="0.75" Y="11.75" Width="1.5" />
+    <NestedTypes>
+      <Class Name="Rollbar.DTOs.Client.ReservedProperties" Collapsed="true">
+        <TypeIdentifier>
+          <NewMemberFileName>DTOs\Client.cs</NewMemberFileName>
+        </TypeIdentifier>
+      </Class>
+    </NestedTypes>
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
       <FileName>DTOs\Client.cs</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Rollbar.DTOs.CodeContext" Collapsed="true">
-    <Position X="5.25" Y="6.25" Width="1.5" />
+  <Class Name="Rollbar.DTOs.CodeContext">
+    <Position X="11.75" Y="6.75" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAEAAAAAAAA=</HashCode>
       <FileName>DTOs\CodeContext.cs</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Rollbar.DTOs.CrashReport" Collapsed="true">
-    <Position X="5.25" Y="4.25" Width="1.5" />
+  <Class Name="Rollbar.DTOs.CrashReport">
+    <Position X="13.5" Y="5" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAACACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
       <FileName>DTOs\CrashReport.cs</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Rollbar.DTOs.Data" Collapsed="true">
-    <Position X="5.25" Y="7.25" Width="1.5" />
+  <Class Name="Rollbar.DTOs.Data">
+    <Position X="7.75" Y="2.75" Width="2" />
     <TypeIdentifier>
       <HashCode>AIAAAAAiCgAAAMAwAAADCAAAAIAAgAABCAAAAggRAAQ=</HashCode>
       <FileName>DTOs\Data.cs</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Rollbar.DTOs.DtoBase" Collapsed="true">
-    <Position X="4.5" Y="0.5" Width="1.5" />
+  <Class Name="Rollbar.DTOs.DtoBase">
+    <Position X="4.5" Y="0.5" Width="2.25" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAACAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAA=</HashCode>
       <FileName>DTOs\DtoBase.cs</FileName>
     </TypeIdentifier>
     <Lollipop Position="0.2" />
   </Class>
-  <Class Name="Rollbar.DTOs.Exception" Collapsed="true">
-    <Position X="5.25" Y="5.25" Width="1.5" />
+  <Class Name="Rollbar.DTOs.Exception">
+    <Position X="13.5" Y="2.75" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAgAAAAAAIAAAAAAAAAAAAAAAAAIAAAAAA=</HashCode>
       <FileName>DTOs\Exception.cs</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Rollbar.DTOs.ExtendableDtoBase" Collapsed="true">
-    <Position X="1.5" Y="1.75" Width="1.5" />
+  <Class Name="Rollbar.DTOs.ExtendableDtoBase">
+    <Position X="0.75" Y="2" Width="2.75" />
     <TypeIdentifier>
       <HashCode>OQIAAAAEIAAEABAQCAAABAQAAAAAAAAEAAAgAABQIAA=</HashCode>
       <FileName>DTOs\ExtendableDtoBase.cs</FileName>
     </TypeIdentifier>
     <Lollipop Position="0.2" />
   </Class>
-  <Class Name="Rollbar.DTOs.Frame" Collapsed="true">
-    <Position X="5.25" Y="9.25" Width="1.5" />
+  <Class Name="Rollbar.DTOs.Frame">
+    <Position X="11.75" Y="2.75" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAAIAAAAAoCAAAAAAAAgAAAAQAAAAAAIAAQAAABEAAg=</HashCode>
       <FileName>DTOs\Frame.cs</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Rollbar.DTOs.Message" Collapsed="true">
-    <Position X="1.25" Y="3.5" Width="1.5" />
+  <Class Name="Rollbar.DTOs.Message">
+    <Position X="2.75" Y="8" Width="1.5" />
+    <NestedTypes>
+      <Class Name="Rollbar.DTOs.Message.ReservedProperties" Collapsed="true">
+        <TypeIdentifier>
+          <NewMemberFileName>DTOs\Message.cs</NewMemberFileName>
+        </TypeIdentifier>
+      </Class>
+    </NestedTypes>
     <TypeIdentifier>
       <HashCode>AAAAAAAAAACAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
       <FileName>DTOs\Message.cs</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Rollbar.DTOs.Payload" Collapsed="true">
-    <Position X="5.25" Y="2.25" Width="1.5" />
+  <Class Name="Rollbar.DTOs.Payload">
+    <Position X="6" Y="2.75" Width="1.5" />
     <TypeIdentifier>
-      <HashCode>AAAAAAAAAACAAAAAAAAAAAAAEAAAABAAAAAAAAAAAAA=</HashCode>
+      <HashCode>AAQAAAAAAACAAAAAAAAAAAAAkAIAABAAAABAAAAAAAA=</HashCode>
       <FileName>DTOs\Payload.cs</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Rollbar.DTOs.Person" Collapsed="true">
-    <Position X="5.25" Y="10.25" Width="1.5" />
+  <Class Name="Rollbar.DTOs.Person">
+    <Position X="6" Y="6.25" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAACAAAAACAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAA=</HashCode>
       <FileName>DTOs\Person.cs</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Rollbar.DTOs.Request" Collapsed="true">
-    <Position X="1.25" Y="6.5" Width="1.5" />
+  <Class Name="Rollbar.DTOs.Request">
+    <Position X="0.75" Y="8" Width="1.5" />
+    <NestedTypes>
+      <Class Name="Rollbar.DTOs.Request.ReservedProperties" Collapsed="true">
+        <TypeIdentifier>
+          <NewMemberFileName>DTOs\Request.cs</NewMemberFileName>
+        </TypeIdentifier>
+      </Class>
+    </NestedTypes>
     <TypeIdentifier>
       <HashCode>AAAAAAIAAAAAAAACAAAgAAgBCAAAgAAECAAAAAAAAAA=</HashCode>
       <FileName>DTOs\Request.cs</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Rollbar.DTOs.Server" Collapsed="true">
-    <Position X="1.25" Y="5.5" Width="1.5" />
+  <Class Name="Rollbar.DTOs.Server">
+    <Position X="2.75" Y="10.75" Width="1.5" />
+    <NestedTypes>
+      <Class Name="Rollbar.DTOs.Server.ReservedProperties" Collapsed="true">
+        <TypeIdentifier>
+          <NewMemberFileName>DTOs\Server.cs</NewMemberFileName>
+        </TypeIdentifier>
+      </Class>
+    </NestedTypes>
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAACAAAAAAAAAAAAAACAgAAAAAAAgAAAA=</HashCode>
       <FileName>DTOs\Server.cs</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Rollbar.DTOs.Trace" Collapsed="true">
-    <Position X="5.25" Y="8.25" Width="1.5" />
+  <Class Name="Rollbar.DTOs.Trace">
+    <Position X="10" Y="6.75" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAE=</HashCode>
       <FileName>DTOs\Trace.cs</FileName>

--- a/Rollbar/ILogger.cs
+++ b/Rollbar/ILogger.cs
@@ -4,10 +4,33 @@
     using System.Collections.Generic;
 
     /// <summary>
+    /// 
     /// Defines ILogger interface.
+    /// 
+    /// NOTE: 
+    /// 
+    /// All the logging methods of this interface imply asynchronous/non-blocking implementation.
+    /// However, the interface defines the method (ILogger AsBlockingLogger(TimeSpan timeout))
+    /// that returns a synchronous implementation of ILogger.
+    /// This approach allows for easier code refactoring when switching between 
+    /// asynchronous and synchronous uses of the logger.
+    /// 
+    /// Normally, you would want to use asynchronous logging since it has virtually no instrumentational 
+    /// overhead on your application execution performance at runtime. It has "fire and forget"
+    /// approach to logging. However, in some specific situations, for example, while logging right before 
+    /// exiting an application, you may want to use it synchronously so that the application
+    /// does not quit before the logging completes.
+    /// 
     /// </summary>
     public interface ILogger
     {
+        /// <summary>
+        /// Returns blocking/synchronous implementation of this ILogger.
+        /// </summary>
+        /// <param name="timeout">The timeout.</param>
+        /// <returns></returns>
+        ILogger AsBlockingLogger(TimeSpan timeout);
+
         /// <summary>
         /// Logs the specified level.
         /// </summary>

--- a/Rollbar/NetFramework/RollbarConfigSection.cs
+++ b/Rollbar/NetFramework/RollbarConfigSection.cs
@@ -1,21 +1,17 @@
 ﻿namespace Rollbar.NetFramework
 {
-#if NETFX_MAX_47
+#if NETFX
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
     using System.Configuration;
-    using System.Diagnostics;
 
     /// <summary>
-    /// Implements Rollbar custom configuration section for .NET4.5-4.7 only!
+    /// Implements Rollbar custom configuration section for .NET Framework only!
     /// </summary>
     /// <seealso cref="System.Configuration.ConfigurationSection" />
     /// <remarks>
     /// http://joelabrahamsson.com/creating-a-custom-configuration-section-in-net/
     /// https://msdn.microsoft.com/en-us/library/system.configuration.configurationsection.aspx
+    /// https://docs.microsoft.com/en-us/dotnet/api/system.configuration.configurationsection?view=netframework-4.7.1
     /// </remarks>
     public class RollbarConfigSection
             : ConfigurationSection
@@ -206,8 +202,5 @@
     }
 #endif
 
-#if NETFX_MIN_471
-
-#endif
 
 }

--- a/Rollbar/NetFramework/RollbarConfigSection.cs
+++ b/Rollbar/NetFramework/RollbarConfigSection.cs
@@ -1,0 +1,213 @@
+﻿namespace Rollbar.NetFramework
+{
+#if NETFX_MAX_47
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Configuration;
+    using System.Diagnostics;
+
+    /// <summary>
+    /// Implements Rollbar custom configuration section for .NET4.5-4.7 only!
+    /// </summary>
+    /// <seealso cref="System.Configuration.ConfigurationSection" />
+    /// <remarks>
+    /// http://joelabrahamsson.com/creating-a-custom-configuration-section-in-net/
+    /// https://msdn.microsoft.com/en-us/library/system.configuration.configurationsection.aspx
+    /// </remarks>
+    public class RollbarConfigSection
+            : ConfigurationSection
+    {
+        /// <summary>
+        /// Gets the configuration.
+        /// </summary>
+        /// <returns></returns>
+        public static RollbarConfigSection GetConfiguration()
+        {
+            RollbarConfigSection configuration =
+                ConfigurationManager.GetSection("rollbar") as RollbarConfigSection;
+
+            if (configuration != null)
+                return configuration;
+
+            return new RollbarConfigSection();
+        }
+
+        /// <summary>
+        /// Gets the access token.
+        /// </summary>
+        /// <value>
+        /// The access token.
+        /// </value>
+        [ConfigurationProperty("accessToken", IsRequired = false)]
+        public string AccessToken
+        {
+            get { return this["accessToken"] as string; }
+        }
+
+        /// <summary>
+        /// Gets or sets the end point.
+        /// </summary>
+        /// <value>
+        /// The end point.
+        /// </value>
+        [ConfigurationProperty("endPoint", IsRequired = false)]
+        public string EndPoint
+        {
+            get { return this["endPoint"] as string; }
+        }
+
+        /// <summary>
+        /// Gets or sets the scrub fields.
+        /// </summary>
+        /// <value>
+        /// The scrub fields.
+        /// </value>
+        [ConfigurationProperty("scrubFields", IsRequired = false)]
+        public string[] ScrubFields
+        {
+            get
+            {
+                string scrubFields = this["scrubFields"] as string;
+                if (string.IsNullOrWhiteSpace(scrubFields))
+                {
+                    return new string[0];
+                }
+
+                return 
+                    scrubFields.Split(new string[] { ", ", "; " }, StringSplitOptions.RemoveEmptyEntries);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the log level.
+        /// </summary>
+        /// <value>
+        /// The log level.
+        /// </value>
+        [ConfigurationProperty("logLevel", IsRequired = false)]
+        public ErrorLevel? LogLevel
+        {
+            get
+            {
+                string logLevelString = this["logLevel"] as string;
+                if (string.IsNullOrWhiteSpace(logLevelString))
+                {
+                    return null;
+                }
+
+                ErrorLevel logLevel;
+                if (Enum.TryParse<ErrorLevel>(logLevelString, out logLevel))
+                {
+                    return logLevel;
+                }
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the enabled.
+        /// </summary>
+        /// <value>
+        /// The enabled.
+        /// </value>
+        [ConfigurationProperty("enabled", IsRequired = false)]
+        public bool? Enabled
+        {
+            get
+            {
+                string stringValue = this["enabled"] as string;
+                if (string.IsNullOrWhiteSpace(stringValue))
+                {
+                    return null;
+                }
+
+                bool enabled;
+                if (bool.TryParse(stringValue, out enabled))
+                {
+                    return enabled;
+                }
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the environment.
+        /// </summary>
+        /// <value>
+        /// The environment.
+        /// </value>
+        [ConfigurationProperty("environment", IsRequired = false)]
+        public string Environment
+        {
+            get { return this["environment"] as string; }
+        }
+
+        /// <summary>
+        /// Gets or sets the proxy address.
+        /// </summary>
+        /// <value>
+        /// The proxy address.
+        /// </value>
+        [ConfigurationProperty("proxyAddress", IsRequired = false)]
+        public string ProxyAddress
+        {
+            get { return this["proxyAddress"] as string; }
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum reports per minute.
+        /// </summary>
+        /// <value>
+        /// The maximum reports per minute.
+        /// </value>
+        [ConfigurationProperty("maxReportsPerMinute", IsRequired = false)]
+        public int? MaxReportsPerMinute
+        {
+            get
+            {
+                return ReadOptionalInt("maxReportsPerMinute");
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the reporting queue depth.
+        /// </summary>
+        /// <value>
+        /// The reporting queue depth.
+        /// </value>
+        [ConfigurationProperty("reportingQueueDepth", IsRequired = false)]
+        public int? ReportingQueueDepth
+        {
+            get
+            {
+                return ReadOptionalInt("reportingQueueDepth");
+            }
+        }
+
+        private int? ReadOptionalInt(string fieldName)
+        {
+            string stringValue = this[fieldName] as string;
+            if (string.IsNullOrWhiteSpace(stringValue))
+            {
+                return null;
+            }
+
+            int intValue;
+            if (int.TryParse(stringValue, out intValue))
+            {
+                return intValue;
+            }
+            return null;
+
+        }
+    }
+#endif
+
+#if NETFX_MIN_471
+
+#endif
+
+}

--- a/Rollbar/Rollbar.csproj
+++ b/Rollbar/Rollbar.csproj
@@ -8,7 +8,6 @@
     <RootNamespace>Rollbar</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>1.0.1</Version>
     
   </PropertyGroup>
 

--- a/Rollbar/Rollbar.csproj
+++ b/Rollbar/Rollbar.csproj
@@ -18,5 +18,5 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
-
+  
 </Project>

--- a/Rollbar/RollbarConfig.cs
+++ b/Rollbar/RollbarConfig.cs
@@ -12,6 +12,7 @@
     /// <summary>
     /// Models Rollbar client/notifier configuration data.
     /// </summary>
+    /// <seealso cref="Rollbar.Common.ReconfigurableBase{Rollbar.RollbarConfig}" />
     /// <seealso cref="Common.ReconfigurableBase{Rollbar.RollbarConfig}" />
     /// <seealso cref="Rollbar.ITraceable" />
     public class RollbarConfig
@@ -90,12 +91,13 @@
             this.Server = null;
             this.Person = null;
 
-#if NETFX_MAX_47
+#if NETFX
+            // initialize based on app.config settings of Rollbar section (if any):
             this.InitFromAppConfig();
 #endif
         }
 
-#if NETFX_MAX_47
+#if NETFX
         private void InitFromAppConfig()
         {
             Rollbar.NetFramework.RollbarConfigSection config = 

--- a/Rollbar/RollbarLogger.cs
+++ b/Rollbar/RollbarLogger.cs
@@ -330,20 +330,13 @@ namespace Rollbar
 
         }
 
-        protected virtual void OnRollbarEvent(RollbarEventArgs e)
+        internal virtual void OnRollbarEvent(RollbarEventArgs e)
         {
-            Task.Factory.StartNew(() => 
+            EventHandler<RollbarEventArgs> handler = InternalEvent;
+            if (handler != null)
             {
-                EventHandler<RollbarEventArgs> handler = InternalEvent;
-                if (handler != null)
-                {
-                    handler(this, e);
-                }
-            },
-            new CancellationToken(),
-            TaskCreationOptions.None,
-            this._nativeTaskScheduler
-            );
+                handler(this, e);
+            }
         }
 
         #region IDisposable Support

--- a/Rollbar/RollbarLogger.cs
+++ b/Rollbar/RollbarLogger.cs
@@ -227,7 +227,7 @@ namespace Rollbar
             SemaphoreSlim signal = null
             )
         {
-            SendBodyAsync(new Body(e), level, custom);
+            SendBodyAsync(new Body(e), level, custom, timeout, signal);
         }
 
         internal void Report(

--- a/Rollbar/RollbarLoggerBlockingWrapper.cs
+++ b/Rollbar/RollbarLoggerBlockingWrapper.cs
@@ -1,0 +1,286 @@
+﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("UnitTest.Rollbar")]
+
+namespace Rollbar
+{
+    using Rollbar.Diagnostics;
+    using Rollbar.DTOs;
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// 
+    /// Implements disposable implementation of IRollbar.
+    /// 
+    /// All the logging methods implemented in synchronous "blocking" fashion.
+    /// Hence, the payload is either delivered or a method timed out when
+    /// the methods return.
+    /// 
+    /// </summary>
+    internal class RollbarLoggerBlockingWrapper
+        : IRollbar
+        , IDisposable
+    {
+        private readonly RollbarLogger _asyncLogger = null;
+        private readonly TimeSpan _timeout;
+
+
+        private void Report(System.Exception e, ErrorLevel? level = ErrorLevel.Error, IDictionary<string, object> custom = null)
+        {
+            using (var signal = this.CreateSignalObject())
+            {
+                this._asyncLogger.Report(e, level, custom, this._timeout, signal);
+
+                WaitAndCompleteReport(signal);
+            }
+        }
+
+        private void Report(string message, ErrorLevel? level = ErrorLevel.Error, IDictionary<string, object> custom = null)
+        {
+            using (var signal = this.CreateSignalObject())
+            {
+                this._asyncLogger.Report(message, level, custom, this._timeout, signal);
+
+                WaitAndCompleteReport(signal);
+            }
+        }
+
+        private SemaphoreSlim CreateSignalObject()
+        {
+            SemaphoreSlim signal = 
+                new SemaphoreSlim(initialCount: 0, maxCount: 1);
+
+            return signal;
+        }
+
+        private void WaitAndCompleteReport(SemaphoreSlim signal)
+        {
+            if (!signal.Wait(this._timeout))
+            {
+                throw new TimeoutException("Posting a payload to the Rollbar API Service timed-out");
+            }
+
+            return;
+        }
+
+        public RollbarLoggerBlockingWrapper(RollbarLogger asyncLogger, TimeSpan timeout)
+        {
+            Assumption.AssertNotNull(asyncLogger, nameof(asyncLogger));
+
+            this._asyncLogger = asyncLogger;
+            this._timeout = timeout;
+        }
+
+        #region ILogger
+
+        public ILogger AsBlockingLogger(TimeSpan timeout)
+        {
+            return new RollbarLoggerBlockingWrapper(this._asyncLogger, timeout);
+        }
+
+        public ILogger Log(ErrorLevel level, object obj, IDictionary<string, object> custom = null)
+        {
+            return this.Log(level, obj.ToString(), custom);
+        }
+
+        public ILogger Log(ErrorLevel level, string msg, IDictionary<string, object> custom = null)
+        {
+            this.Report(msg, level, custom);
+
+            return this;
+        }
+
+        public ILogger Critical(string msg, IDictionary<string, object> custom = null)
+        {
+            return this.Log(ErrorLevel.Critical, msg, custom);
+        }
+
+        public ILogger Error(string msg, IDictionary<string, object> custom = null)
+        {
+            return this.Log(ErrorLevel.Error, msg, custom);
+        }
+
+        public ILogger Warning(string msg, IDictionary<string, object> custom = null)
+        {
+            return this.Log(ErrorLevel.Warning, msg, custom);
+        }
+
+        public ILogger Info(string msg, IDictionary<string, object> custom = null)
+        {
+            return this.Log(ErrorLevel.Info, msg, custom);
+        }
+
+        public ILogger Debug(string msg, IDictionary<string, object> custom = null)
+        {
+            return this.Log(ErrorLevel.Debug, msg, custom);
+        }
+
+
+        public ILogger Critical(System.Exception error, IDictionary<string, object> custom = null)
+        {
+            this.Report(error, ErrorLevel.Critical, custom);
+
+            return this;
+        }
+
+        public ILogger Error(System.Exception error, IDictionary<string, object> custom = null)
+        {
+            this.Report(error, ErrorLevel.Error, custom);
+
+            return this;
+        }
+
+        public ILogger Warning(System.Exception error, IDictionary<string, object> custom = null)
+        {
+            this.Report(error, ErrorLevel.Error, custom);
+
+            return this;
+        }
+
+        public ILogger Info(System.Exception error, IDictionary<string, object> custom = null)
+        {
+            this.Report(error, ErrorLevel.Error, custom);
+
+            return this;
+        }
+
+        public ILogger Debug(System.Exception error, IDictionary<string, object> custom = null)
+        {
+            this.Report(error, ErrorLevel.Error, custom);
+
+            return this;
+        }
+
+
+        public ILogger Critical(ITraceable traceableObj, IDictionary<string, object> custom = null)
+        {
+            return this.Critical(traceableObj.TraceAsString(), custom);
+        }
+
+        public ILogger Error(ITraceable traceableObj, IDictionary<string, object> custom = null)
+        {
+            return this.Error(traceableObj.TraceAsString(), custom);
+        }
+
+        public ILogger Warning(ITraceable traceableObj, IDictionary<string, object> custom = null)
+        {
+            return this.Warning(traceableObj.TraceAsString(), custom);
+        }
+
+        public ILogger Info(ITraceable traceableObj, IDictionary<string, object> custom = null)
+        {
+            return this.Info(traceableObj.TraceAsString(), custom);
+        }
+
+        public ILogger Debug(ITraceable traceableObj, IDictionary<string, object> custom = null)
+        {
+            return this.Debug(traceableObj.TraceAsString(), custom);
+        }
+
+
+
+        public ILogger Critical(object obj, IDictionary<string, object> custom = null)
+        {
+            return this.Critical(obj.ToString(), custom);
+        }
+
+        public ILogger Error(object obj, IDictionary<string, object> custom = null)
+        {
+            return this.Error(obj.ToString(), custom);
+        }
+
+        public ILogger Warning(object obj, IDictionary<string, object> custom = null)
+        {
+            return this.Warning(obj.ToString(), custom);
+        }
+
+        public ILogger Info(object obj, IDictionary<string, object> custom = null)
+        {
+            return this.Info(obj.ToString(), custom);
+        }
+
+        public ILogger Debug(object obj, IDictionary<string, object> custom = null)
+        {
+            return this.Debug(obj.ToString(), custom);
+        }
+
+        #endregion ILogger
+
+
+        #region IRollbar
+
+        public ILogger Logger => this;
+
+        public RollbarConfig Config
+        {
+            get { return this._asyncLogger.Config; }
+        }
+
+        public IRollbar Configure(RollbarConfig settings)
+        {
+            this._asyncLogger.Config.Reconfigure(settings);
+
+            return this;
+        }
+
+        public IRollbar Configure(string accessToken)
+        {
+            this._asyncLogger.Config.Reconfigure(new RollbarConfig(accessToken));
+
+            return this;
+        }
+
+        public event EventHandler<RollbarEventArgs> InternalEvent
+        {
+            add { this._asyncLogger.InternalEvent += value; }
+            remove { this._asyncLogger.InternalEvent -= value; }
+        }
+
+        #endregion IRollbar
+
+        #region IDisposable Support
+
+        private bool disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    // TODO: dispose managed state (managed objects).
+                    this._asyncLogger.Dispose();
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
+                // TODO: set large fields to null.
+
+                disposedValue = true;
+            }
+        }
+
+        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
+        // ~RollbarLoggerBlockingWrapper() {
+        //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+        //   Dispose(false);
+        // }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        /// <remarks>
+        /// This code added to correctly implement the disposable pattern.
+        /// </remarks>
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+            // TODO: uncomment the following line if the finalizer is overridden above.
+            // GC.SuppressFinalize(this);
+        }
+
+        #endregion IDisposable Support
+
+    }
+}

--- a/Rollbar/RollbarQueueController.cs
+++ b/Rollbar/RollbarQueueController.cs
@@ -203,13 +203,13 @@ namespace Rollbar
                         case (int)RollbarApiErrorEventArgs.RollbarError.TooManyRequests:
                             ObeyPayloadTimeout(payload, queue);
                             tokenMetadata.IncrementTokenUsageDelay();
-                            OnRollbarEvent(
+                            this.OnRollbarEvent(
                                 new RollbarApiErrorEventArgs(queue.Logger.Config, payload, response)
                                 );
                             return;
                         default:
                             ObeyPayloadTimeout(payload, queue);
-                            OnRollbarEvent(
+                            this.OnRollbarEvent(
                                 new RollbarApiErrorEventArgs(queue.Logger.Config, payload, response)
                                 );
                             break;
@@ -333,6 +333,8 @@ namespace Rollbar
             {
                 handler(this, e);
             }
+
+            e?.Config?.Logger?.OnRollbarEvent(e);
         }
 
     }

--- a/Rollbar/RollbarQueueController.cs
+++ b/Rollbar/RollbarQueueController.cs
@@ -64,6 +64,10 @@ namespace Rollbar
 
         #endregion singleton implementation
 
+
+        private readonly TimeSpan _sleepInterval = TimeSpan.FromMilliseconds(250);
+
+
         /// <summary>
         /// Occurs after a Rollbar internal event happens.
         /// </summary>
@@ -135,8 +139,6 @@ namespace Rollbar
 
         private void KeepProcessingAllQueues()
         {
-            TimeSpan sleepInterval = TimeSpan.FromMilliseconds(250);
-
             while(true)
             {
                 try
@@ -146,7 +148,7 @@ namespace Rollbar
                         ProcessAllQueuesOnce();
                     }
 
-                    Thread.Sleep(sleepInterval);
+                    Thread.Sleep(this._sleepInterval);
                 }
 #pragma warning disable CS0168 // Variable is declared but never used
                 catch (System.Exception ex)
@@ -194,16 +196,19 @@ namespace Rollbar
                     switch (response.Error)
                     {
                         case (int)RollbarApiErrorEventArgs.RollbarError.None:
+                            payload.Signal?.Release();
                             queue.Dequeue();
                             tokenMetadata.ResetTokenUsageDelay();
                             break;
                         case (int)RollbarApiErrorEventArgs.RollbarError.TooManyRequests:
+                            ObeyPayloadTimeout(payload, queue);
                             tokenMetadata.IncrementTokenUsageDelay();
                             OnRollbarEvent(
                                 new RollbarApiErrorEventArgs(queue.Logger.Config, payload, response)
                                 );
                             return;
                         default:
+                            ObeyPayloadTimeout(payload, queue);
                             OnRollbarEvent(
                                 new RollbarApiErrorEventArgs(queue.Logger.Config, payload, response)
                                 );
@@ -211,6 +216,14 @@ namespace Rollbar
                     }
 
                 }
+            }
+        }
+
+        private void ObeyPayloadTimeout(Payload payload, PayloadQueue queue)
+        {
+            if (payload.TimeoutAt.HasValue && (DateTime.Now.Add(this._sleepInterval) >= payload.TimeoutAt.Value))
+            {
+                queue.Dequeue();
             }
         }
 

--- a/Rollbar/_Rollbar.cd
+++ b/Rollbar/_Rollbar.cd
@@ -1,0 +1,119 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ClassDiagram MajorVersion="1" MinorVersion="1" MembersFormat="FullSignature">
+  <Class Name="Rollbar.RollbarLocator">
+    <Position X="0.5" Y="6.25" Width="3.5" />
+    <Compartments>
+      <Compartment Name="Nested Types" Collapsed="false" />
+    </Compartments>
+    <NestedTypes>
+      <Class Name="Rollbar.RollbarLocator.NestedSingleInstance" Collapsed="true">
+        <TypeIdentifier>
+          <NewMemberFileName>RollbarLocator.cs</NewMemberFileName>
+        </TypeIdentifier>
+      </Class>
+    </NestedTypes>
+    <TypeIdentifier>
+      <HashCode>AAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>RollbarLocator.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Rollbar.RollbarConfig">
+    <Position X="0.5" Y="0.5" Width="3.5" />
+    <TypeIdentifier>
+      <HashCode>AIACAAACAAIAQYAAAAAAkAUCMABAAAIQAAAAAgAAAAA=</HashCode>
+      <FileName>RollbarConfig.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="Rollbar.RollbarFactory">
+    <Position X="0.5" Y="8.5" Width="3.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>RollbarFactory.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Rollbar.RollbarQueueController">
+    <Position X="4.25" Y="9" Width="5.5" />
+    <NestedTypes>
+      <Class Name="Rollbar.RollbarQueueController.NestedSingleInstance" Collapsed="true">
+        <TypeIdentifier>
+          <NewMemberFileName>RollbarQueueController.cs</NewMemberFileName>
+        </TypeIdentifier>
+      </Class>
+    </NestedTypes>
+    <TypeIdentifier>
+      <HashCode>AAAAACAAAAAEAAgAUgAAAAAACIAJBAAAQAIAAAIAEAA=</HashCode>
+      <FileName>RollbarQueueController.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Rollbar.RollbarApiErrorEventArgs">
+    <Position X="10.75" Y="8.5" Width="6.5" />
+    <NestedTypes>
+      <Enum Name="Rollbar.RollbarApiErrorEventArgs.RollbarError" Collapsed="true">
+        <TypeIdentifier>
+          <NewMemberFileName>RollbarApiErrorEventArgs.cs</NewMemberFileName>
+        </TypeIdentifier>
+      </Enum>
+      <Class Name="Rollbar.RollbarApiErrorEventArgs.RollbarErrorDetails" Collapsed="true">
+        <TypeIdentifier>
+          <NewMemberFileName>RollbarApiErrorEventArgs.cs</NewMemberFileName>
+        </TypeIdentifier>
+      </Class>
+    </NestedTypes>
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAQAAAAAAAAAAAAAgCAAEQBAAAAAAAAAA=</HashCode>
+      <FileName>RollbarApiErrorEventArgs.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Rollbar.RollbarEventArgs">
+    <Position X="10.75" Y="0.75" Width="6.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAgAAAAAAAAAQAAAAAAAAAAAQAAAAAAAAAAA=</HashCode>
+      <FileName>RollbarEventArgs.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="Rollbar.CommunicationEventArgs">
+    <Position X="10.75" Y="6.25" Width="6.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAABAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAA=</HashCode>
+      <FileName>CommunicationEventArgs.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Rollbar.CommunicationErrorEventArgs">
+    <Position X="10.75" Y="3.75" Width="6.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAQAAAAAACAAAAAAAAAAQAAAAAAAAAAA=</HashCode>
+      <FileName>CommunicationErrorEventArgs.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Interface Name="Rollbar.IRollbar">
+    <Position X="4.25" Y="6" Width="5.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAgIAAAAAQABAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>IRollbar.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="Rollbar.ILogger">
+    <Position X="4.25" Y="0.5" Width="5.5" />
+    <TypeIdentifier>
+      <HashCode>AAAIAAAAAAAAAYAAAAAAABAAAAgAAAAAAAAAAEAAAAA=</HashCode>
+      <FileName>ILogger.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="Rollbar.ITraceable">
+    <Position X="0.5" Y="10" Width="3.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAA=</HashCode>
+      <FileName>ITraceable.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Enum Name="Rollbar.ErrorLevel">
+    <Position X="0.5" Y="11.25" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAIAAAAAAAAAYAAAAAAABAAAAAAAAAAAAAAAEAAAAA=</HashCode>
+      <FileName>ErrorLevel.cs</FileName>
+    </TypeIdentifier>
+  </Enum>
+  <Font Name="Segoe UI" Size="9" />
+</ClassDiagram>

--- a/Sample.Net.ConsoleApp/App.config
+++ b/Sample.Net.ConsoleApp/App.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="rollbar" type="Rollbar.NetFramework.RollbarConfigSection, Rollbar"/>
+  </configSections>
+  
+  <rollbar 
+    accessToken="17965fa5041749b6bf7095a190001ded" 
+    environment="RollbarNetSamples" 
+    />
+
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+  </startup>
+
+</configuration>

--- a/Sample.Net.ConsoleApp/Program.cs
+++ b/Sample.Net.ConsoleApp/Program.cs
@@ -12,7 +12,15 @@
     {
         static void Main(string[] args)
         {
+            // NOTE: when the next line is commented out, 
+            // the Rollbar notifier will still be properly configured via app.config:
             //ConfigureRollbarSingleton();
+
+            // ConfigureRollbarSingleton() is called above,
+            // the next code line could be commented out:
+            RollbarLocator.RollbarInstance
+                .InternalEvent += OnRollbarInternalEvent
+                ;
 
             RollbarLocator.RollbarInstance
                 .Info("ConsoleApp sample: Basic info log example.")

--- a/Sample.Net.ConsoleApp/Program.cs
+++ b/Sample.Net.ConsoleApp/Program.cs
@@ -1,0 +1,112 @@
+﻿namespace Sample.Net.ConsoleApp
+{
+    using Rollbar;
+    using Rollbar.DTOs;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            //ConfigureRollbarSingleton();
+
+            RollbarLocator.RollbarInstance
+                .Info("ConsoleApp sample: Basic info log example.")
+                .Debug("ConsoleApp sample: First debug log.")
+                .Error(new NullReferenceException("ConsoleApp sample: null reference exception."))
+                .Error(new System.Exception("ConsoleApp sample: trying out the TraceChain", new NullReferenceException()))
+                ;
+
+            RollbarLocator.RollbarInstance
+                .Info("Via no-blocking mechanism.")
+                ;
+
+            Console.WriteLine("Press Enter key to exit...");
+            Console.ReadLine();
+        }
+
+        /// <summary>
+        /// Configures the Rollbar singleton-like notifier.
+        /// </summary>
+        private static void ConfigureRollbarSingleton()
+        {
+            const string rollbarAccessToken = "17965fa5041749b6bf7095a190001ded";
+            const string rollbarEnvironment = "RollbarNetSamples";
+
+            var config = new RollbarConfig(rollbarAccessToken) // minimally required Rollbar configuration
+            {
+                Environment = rollbarEnvironment,
+                ScrubFields = new string[]
+                {
+                    "access_token", // normally, you do not want scrub this specific field (it is operationally critical), but it just proves safety net built into the notifier... 
+                    "username",
+                }
+            };
+            RollbarLocator.RollbarInstance
+                // minimally required Rollbar configuration:
+                .Configure(config)
+                // optional step if you would like to monitor this Rollbar instance's internal events within your application:
+                .InternalEvent += OnRollbarInternalEvent
+                ;
+
+            // optional step if you would like to monitor all Rollbar instances' internal events within your application:
+            //RollbarQueueController.Instance.InternalEvent += OnRollbarInternalEvent;
+
+            // Optional info about reporting Rollbar user:
+            SetRollbarReportingUser("007", "jbond@mi6.uk", "JBOND");
+        }
+
+        /// <summary>
+        /// Sets the rollbar reporting user.
+        /// </summary>
+        /// <param name="id">The identifier.</param>
+        /// <param name="email">The email.</param>
+        /// <param name="userName">Name of the user.</param>
+        private static void SetRollbarReportingUser(string id, string email, string userName)
+        {
+            Person person = new Person(id);
+            person.Email = email;
+            person.UserName = userName;
+            RollbarLocator.RollbarInstance.Config.Person = person;
+        }
+
+        /// <summary>
+        /// Called when rollbar internal event is detected.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">The <see cref="RollbarEventArgs"/> instance containing the event data.</param>
+        private static void OnRollbarInternalEvent(object sender, RollbarEventArgs e)
+        {
+            Console.WriteLine(e.TraceAsString());
+
+            RollbarApiErrorEventArgs apiErrorEvent = e as RollbarApiErrorEventArgs;
+            if (apiErrorEvent != null)
+            {
+                //TODO: handle/report Rollbar API communication error event...
+                return;
+            }
+            CommunicationEventArgs commEvent = e as CommunicationEventArgs;
+            if (commEvent != null)
+            {
+                //TODO: handle/report Rollbar API communication event...
+                return;
+            }
+            CommunicationErrorEventArgs commErrorEvent = e as CommunicationErrorEventArgs;
+            if (commErrorEvent != null)
+            {
+                //TODO: handle/report basic communication error while attempting to reach Rollbar API service... 
+                return;
+            }
+            InternalErrorEventArgs internalErrorEvent = e as InternalErrorEventArgs;
+            if (internalErrorEvent != null)
+            {
+                //TODO: handle/report basic internal error while using the Rollbar Notifier... 
+                return;
+            }
+        }
+    }
+}

--- a/Sample.Net.ConsoleApp/Properties/AssemblyInfo.cs
+++ b/Sample.Net.ConsoleApp/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Sample.Net.ConsoleApp")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Sample.Net.ConsoleApp")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b75eb341-10cc-4c91-9f8e-c6efa3817f57")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Sample.Net.ConsoleApp/Sample.Net.ConsoleApp.csproj
+++ b/Sample.Net.ConsoleApp/Sample.Net.ConsoleApp.csproj
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B75EB341-10CC-4C91-9F8E-C6EFA3817F57}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Sample.Net.ConsoleApp</RootNamespace>
+    <AssemblyName>Sample.Net.ConsoleApp</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Rollbar\Rollbar.csproj">
+      <Project>{fa70ac31-5cd9-4947-8d5f-624d9a1fb510}</Project>
+      <Name>Rollbar</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Sample.NetCore.ConsoleApp/Program.cs
+++ b/Sample.NetCore.ConsoleApp/Program.cs
@@ -2,6 +2,7 @@
 using Rollbar.DTOs;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Sample.NetCore.ConsoleApp
 {
@@ -26,8 +27,50 @@ namespace Sample.NetCore.ConsoleApp
                 .Error(new System.Exception("ConsoleApp sample: trying out the TraceChain", new NullReferenceException()))
                 ;
 
-            System.Threading.Thread.Sleep(TimeSpan.FromSeconds(10));
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            RollbarLocator.RollbarInstance
+                .Info("Via no-blocking mechanism.")
+                ;
+            stopwatch.Stop();
+            string msg = "*** 1. No-blocking report took " + stopwatch.Elapsed.TotalMilliseconds + " [msec].";
+            System.Diagnostics.Trace.WriteLine(msg);
+            Console.WriteLine(msg);
 
+            stopwatch = Stopwatch.StartNew();
+            try
+            {
+                RollbarLocator.RollbarInstance.AsBlockingLogger(TimeSpan.FromMilliseconds(10000))
+                    .Info("Via blocking mechanism.")
+                    ;
+            }
+            catch (System.TimeoutException ex)
+            {
+                msg = "*** Blocking call with too short timeout. Exception: " + Environment.NewLine + ex;
+                System.Diagnostics.Trace.WriteLine(msg);
+                Console.WriteLine(msg);
+            }
+            stopwatch.Stop();
+            msg = "*** 2. Blocking (long timeout) report took " + stopwatch.Elapsed.TotalMilliseconds + " [msec].";
+            System.Diagnostics.Trace.WriteLine(msg);
+            Console.WriteLine(msg);
+
+            stopwatch = Stopwatch.StartNew();
+            try
+            {
+                RollbarLocator.RollbarInstance.AsBlockingLogger(TimeSpan.FromMilliseconds(500))
+                    .Info("Via blocking mechanism with short timeout.")
+                    ;
+            }
+            catch (System.TimeoutException ex)
+            {
+                msg = "*** 3. Blocking call with too short timeout. Exception: " + Environment.NewLine + ex;
+                System.Diagnostics.Trace.WriteLine(msg);
+                Console.WriteLine(msg);
+            }
+            stopwatch.Stop();
+            msg = "*** Blocking (short timeout) report took " + stopwatch.Elapsed.TotalMilliseconds + " [msec].";
+            System.Diagnostics.Trace.WriteLine(msg);
+            Console.WriteLine(msg);
         }
 
         /// <summary>

--- a/Sample.NetCore.ConsoleApp/Program.cs
+++ b/Sample.NetCore.ConsoleApp/Program.cs
@@ -93,9 +93,12 @@ namespace Sample.NetCore.ConsoleApp
             RollbarLocator.RollbarInstance
                 // minimally required Rollbar configuration:
                 .Configure(config)
-                // optional step if you would like to monitor Rollbar internal events within your application:
+                // optional step if you would like to monitor this Rollbar instance's internal events within your application:
                 .InternalEvent += OnRollbarInternalEvent
                 ;
+
+            // optional step if you would like to monitor all Rollbar instances' internal events within your application:
+            RollbarQueueController.Instance.InternalEvent += OnRollbarInternalEvent;
 
             // Optional info about reporting Rollbar user:
             SetRollbarReportingUser("007", "jbond@mi6.uk", "JBOND");

--- a/SolutionCommon.csproj
+++ b/SolutionCommon.csproj
@@ -34,6 +34,17 @@
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net47' 
+             Or '$(TargetFramework)' == 'net462' 
+             Or '$(TargetFramework)' == 'net461' 
+             Or '$(TargetFramework)' == 'net46'
+             Or '$(TargetFramework)' == 'net452'
+             Or '$(TargetFramework)' == 'net451'
+             Or '$(TargetFramework)' == 'net45'
+             ">
+    <DefineConstants>NETFX_MAX_47</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net471' 
              Or '$(TargetFramework)' == 'net47' 
              Or '$(TargetFramework)' == 'net462' 
@@ -43,6 +54,7 @@
              Or '$(TargetFramework)' == 'net451'
              Or '$(TargetFramework)' == 'net45'
              ">
+    <Reference Include="System.Configuration" Version="4.0.0.0" />
     <Reference Include="System.Net" Version="4.0.0.0" />
     <Reference Include="System.Net.Http" Version="4.0.0.0" />
   </ItemGroup>

--- a/SolutionCommon.csproj
+++ b/SolutionCommon.csproj
@@ -4,7 +4,10 @@
 
     <TargetFrameworks>net471;net47;net462;net461;net46;net452;net451;net45;netstandard2.0;netcoreapp2.0</TargetFrameworks>
 
-    <Version>1.0.1</Version>
+    <NotifierVersion>1.0.2</NotifierVersion>
+    <Version>$(NotifierVersion)</Version>
+    <AssemblyVersion>$(NotifierVersion)</AssemblyVersion>
+    <FileVersion>$(NotifierVersion)</FileVersion>
     <Authors>Andrey Kornich (Wide Spectrum Computing LLC), Chris Pfohl, Daniel Steuernol</Authors>
     <Company>Rollbar Inc</Company>
     <Product>Rollbar.Net Notifier</Product>

--- a/SolutionCommon.csproj
+++ b/SolutionCommon.csproj
@@ -34,7 +34,8 @@
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net47' 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net471'
+             Or '$(TargetFramework)' == 'net47' 
              Or '$(TargetFramework)' == 'net462' 
              Or '$(TargetFramework)' == 'net461' 
              Or '$(TargetFramework)' == 'net46'
@@ -42,7 +43,7 @@
              Or '$(TargetFramework)' == 'net451'
              Or '$(TargetFramework)' == 'net45'
              ">
-    <DefineConstants>NETFX_MAX_47</DefineConstants>
+    <DefineConstants>NETFX</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net471' 
@@ -54,9 +55,9 @@
              Or '$(TargetFramework)' == 'net451'
              Or '$(TargetFramework)' == 'net45'
              ">
-    <Reference Include="System.Configuration" Version="4.0.0.0" />
-    <Reference Include="System.Net" Version="4.0.0.0" />
-    <Reference Include="System.Net.Http" Version="4.0.0.0" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
 </Project>

--- a/UnitTest.Rollbar/AccessTokenQueuesMetadataFixture.cs
+++ b/UnitTest.Rollbar/AccessTokenQueuesMetadataFixture.cs
@@ -7,7 +7,7 @@ namespace UnitTest.Rollbar
     using System;
 
     [TestClass]
-    [TestCategory("AccessTokenQueuesMetadataFixture")]
+    [TestCategory(nameof(AccessTokenQueuesMetadataFixture))]
     public class AccessTokenQueuesMetadataFixture
     {
         [TestInitialize]

--- a/UnitTest.Rollbar/DTOs/BodyFixture.cs
+++ b/UnitTest.Rollbar/DTOs/BodyFixture.cs
@@ -11,7 +11,7 @@ namespace UnitTest.Rollbar.DTOs
     using System.Threading.Tasks;
 
     [TestClass]
-    [TestCategory("BodyFixture")]
+    [TestCategory(nameof(BodyFixture))]
     public class BodyFixture
     {
         [TestInitialize]

--- a/UnitTest.Rollbar/DTOs/ClientFixture.cs
+++ b/UnitTest.Rollbar/DTOs/ClientFixture.cs
@@ -11,7 +11,7 @@ namespace UnitTest.Rollbar.DTOs
     using System.Threading.Tasks;
 
     [TestClass]
-    [TestCategory("ClientFixture")]
+    [TestCategory(nameof(ClientFixture))]
     public class ClientFixture
     {
         private Client _client;

--- a/UnitTest.Rollbar/DTOs/CodeContextFixture.cs
+++ b/UnitTest.Rollbar/DTOs/CodeContextFixture.cs
@@ -13,7 +13,7 @@ namespace UnitTest.Rollbar.DTOs
     using System.Threading.Tasks;
 
     [TestClass]
-    [TestCategory("CodeContextFixture")]
+    [TestCategory(nameof(CodeContextFixture))]
     public class CodeContextFixture
     {
         private CodeContext _codeContext;

--- a/UnitTest.Rollbar/DTOs/DataFixture.cs
+++ b/UnitTest.Rollbar/DTOs/DataFixture.cs
@@ -15,7 +15,7 @@ namespace UnitTest.Rollbar.DTOs
     using System.Threading.Tasks;
 
     [TestClass]
-    [TestCategory("DataFixture")]
+    [TestCategory(nameof(DataFixture))]
     public class DataFixture
     {
         private static readonly Regex WhiteSpace = new Regex(@"\s");

--- a/UnitTest.Rollbar/DTOs/ExceptionFixture.cs
+++ b/UnitTest.Rollbar/DTOs/ExceptionFixture.cs
@@ -11,7 +11,7 @@ namespace UnitTest.Rollbar.DTOs
     using System.Threading.Tasks;
 
     [TestClass]
-    [TestCategory("ExceptionFixture")]
+    [TestCategory(nameof(ExceptionFixture))]
     public class ExceptionFixture
     {
         [TestMethod]

--- a/UnitTest.Rollbar/DTOs/FrameFixture.cs
+++ b/UnitTest.Rollbar/DTOs/FrameFixture.cs
@@ -15,7 +15,7 @@ namespace UnitTest.Rollbar.DTOs
     using System.Threading.Tasks;
 
     [TestClass]
-    [TestCategory("FrameFixture")]
+    [TestCategory(nameof(FrameFixture))]
     public class FrameFixture
     {
         [TestMethod]

--- a/UnitTest.Rollbar/DTOs/MessageFixture.cs
+++ b/UnitTest.Rollbar/DTOs/MessageFixture.cs
@@ -10,7 +10,7 @@ namespace UnitTest.Rollbar.DTOs
     using System.Collections.Generic;
 
     [TestClass]
-    [TestCategory("MessageFixture")]
+    [TestCategory(nameof(MessageFixture))]
     public class MessageFixture
     {
         private Message _message;

--- a/UnitTest.Rollbar/DTOs/PayloadFixture.cs
+++ b/UnitTest.Rollbar/DTOs/PayloadFixture.cs
@@ -13,7 +13,7 @@ namespace UnitTest.Rollbar.DTOs
     using System.Threading.Tasks;
 
     [TestClass]
-    [TestCategory("PayloadFixture")]
+    [TestCategory(nameof(PayloadFixture))]
     public class PayloadFixture
     {
         private Payload _exceptionExample;

--- a/UnitTest.Rollbar/DTOs/PersonFixture.cs
+++ b/UnitTest.Rollbar/DTOs/PersonFixture.cs
@@ -10,7 +10,7 @@ namespace UnitTest.Rollbar.DTOs
     using System.Collections.Generic;
 
     [TestClass]
-    [TestCategory("PersonFixture")]
+    [TestCategory(nameof(PersonFixture))]
     public class PersonFixture
     {
         [TestInitialize]

--- a/UnitTest.Rollbar/DTOs/RequestFixture.cs
+++ b/UnitTest.Rollbar/DTOs/RequestFixture.cs
@@ -12,7 +12,7 @@ namespace UnitTest.Rollbar.DTOs
     using System.Linq;
 
     [TestClass]
-    [TestCategory("RequestFixture")]
+    [TestCategory(nameof(RequestFixture))]
     public class RequestFixture
     {
         private Request _request;

--- a/UnitTest.Rollbar/DTOs/ServerFixture.cs
+++ b/UnitTest.Rollbar/DTOs/ServerFixture.cs
@@ -11,7 +11,7 @@ namespace UnitTest.Rollbar.DTOs
     using System.Collections.Generic;
 
     [TestClass]
-    [TestCategory("ServerFixture")]
+    [TestCategory(nameof(ServerFixture))]
     public class ServerFixture
     {
         private Server _server;

--- a/UnitTest.Rollbar/DTOs/TraceFixture.cs
+++ b/UnitTest.Rollbar/DTOs/TraceFixture.cs
@@ -11,7 +11,7 @@ namespace UnitTest.Rollbar.DTOs
     using System.Linq;
 
     [TestClass]
-    [TestCategory("TraceFixture")]
+    [TestCategory(nameof(TraceFixture))]
     public class TraceFixture
     {
         [TestInitialize]

--- a/UnitTest.Rollbar/PayloadQueueFixture.cs
+++ b/UnitTest.Rollbar/PayloadQueueFixture.cs
@@ -7,7 +7,7 @@ namespace UnitTest.Rollbar
     using System.Threading;
 
     [TestClass]
-    [TestCategory("PayloadQueueFixture")]
+    [TestCategory(nameof(PayloadQueueFixture))]
     public class PayloadQueueFixture
     {
         [TestInitialize]

--- a/UnitTest.Rollbar/RollbarClientFixture.cs
+++ b/UnitTest.Rollbar/RollbarClientFixture.cs
@@ -8,7 +8,7 @@ namespace UnitTest.Rollbar
     using System.Threading;
 
     [TestClass]
-    [TestCategory("RollbarClientFixture")]
+    [TestCategory(nameof(RollbarClientFixture))]
     public class RollbarClientFixture
     {
 

--- a/UnitTest.Rollbar/RollbarFactoryFixture.cs
+++ b/UnitTest.Rollbar/RollbarFactoryFixture.cs
@@ -8,7 +8,7 @@ namespace UnitTest.Rollbar
     using System.Threading;
 
     [TestClass]
-    [TestCategory("RollbarFactoryFixture")]
+    [TestCategory(nameof(RollbarFactoryFixture))]
     public class RollbarFactoryFixture
     {
 

--- a/UnitTest.Rollbar/RollbarLocatorFixture.cs
+++ b/UnitTest.Rollbar/RollbarLocatorFixture.cs
@@ -12,7 +12,7 @@ namespace UnitTest.Rollbar
     using System.Threading.Tasks;
 
     [TestClass]
-    [TestCategory("RollbarLocatorFixture")]
+    [TestCategory(nameof(RollbarLocatorFixture))]
     public class RollbarLocatorFixture
     {
 

--- a/UnitTest.Rollbar/RollbarLocatorFixture.cs
+++ b/UnitTest.Rollbar/RollbarLocatorFixture.cs
@@ -43,7 +43,7 @@ namespace UnitTest.Rollbar
         }
 
         [TestMethod]
-        [Timeout(5000)]
+        [Timeout(10000)]
         public void LocatesTheSameInstanceInMultithreadedEnvironment()
         {
             const int maxIterations = 100;

--- a/UnitTest.Rollbar/RollbarLoggerBlockingWrapperFixture.cs
+++ b/UnitTest.Rollbar/RollbarLoggerBlockingWrapperFixture.cs
@@ -1,0 +1,87 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+namespace UnitTest.Rollbar
+{
+    using global::Rollbar;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
+    using System.Diagnostics;
+    using System.Threading;
+
+    [TestClass]
+    [TestCategory(nameof(RollbarLoggerBlockingWrapperFixture))]
+    public class RollbarLoggerBlockingWrapperFixture
+    {
+        private IRollbar _logger = null;
+
+        [TestInitialize]
+        public void SetupFixture()
+        {
+            SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+
+            RollbarConfig loggerConfig =
+                new RollbarConfig(RollbarUnitTestSettings.AccessToken) { Environment = RollbarUnitTestSettings.Environment, };
+            _logger = RollbarFactory.CreateNew().Configure(loggerConfig);
+        }
+
+        [TestCleanup]
+        public void TearDownFixture()
+        {
+
+        }
+
+        [TestMethod]
+        public void HasBlockingBehavior()
+        {
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            _logger.Info("Via no-blocking mechanism.");
+            stopwatch.Stop();
+            var noblockingCallDuration = stopwatch.Elapsed.TotalMilliseconds ;
+
+            stopwatch = Stopwatch.StartNew();
+            try
+            {
+                _logger.AsBlockingLogger(TimeSpan.FromMilliseconds(10000))
+                    .Info("Via blocking mechanism.")
+                    ;
+            }
+            catch (System.TimeoutException ex)
+            {
+                Assert.Fail("The timeout should be large enough for this test!");
+            }
+            stopwatch.Stop();
+            var blockingCallDuration = stopwatch.Elapsed.TotalMilliseconds;
+
+            Assert.IsTrue(blockingCallDuration > (10 * noblockingCallDuration));
+        }
+
+        [TestMethod]
+        public void TimeoutWorks()
+        {
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            _logger.Info("Via no-blocking mechanism.");
+            stopwatch.Stop();
+            var noblockingCallDuration = stopwatch.Elapsed.TotalMilliseconds;
+
+            stopwatch = Stopwatch.StartNew();
+            try
+            {
+                // the timeout has to be significantly larger than no-blocking call duration 
+                // but smaller than time needed to succeed a blocking call:
+                _logger.AsBlockingLogger(TimeSpan.FromMilliseconds(100))
+                    .Info("Via blocking mechanism.")
+                    ;
+            }
+            catch (System.TimeoutException ex)
+            {
+                stopwatch.Stop();
+                var blockingCallDuration = stopwatch.Elapsed.TotalMilliseconds;
+                Assert.IsTrue(blockingCallDuration > (3 * noblockingCallDuration)); 
+                return;
+            }
+
+            Assert.Fail("The timeout should be small enough for this test to trigger the TimeoutException!");
+        }
+
+    }
+}

--- a/UnitTest.Rollbar/RollbarLoggerBlockingWrapperFixture.cs
+++ b/UnitTest.Rollbar/RollbarLoggerBlockingWrapperFixture.cs
@@ -36,7 +36,7 @@ namespace UnitTest.Rollbar
             Stopwatch stopwatch = Stopwatch.StartNew();
             _logger.Info("Via no-blocking mechanism.");
             stopwatch.Stop();
-            var noblockingCallDuration = stopwatch.Elapsed.TotalMilliseconds ;
+            var noblockingCallDuration = stopwatch.Elapsed.TotalMilliseconds;
 
             stopwatch = Stopwatch.StartNew();
             try

--- a/UnitTest.Rollbar/RollbarLoggerFixture.cs
+++ b/UnitTest.Rollbar/RollbarLoggerFixture.cs
@@ -8,7 +8,7 @@ namespace UnitTest.Rollbar
     using System.Threading;
 
     [TestClass]
-    [TestCategory("RollbarLoggerFixture")]
+    [TestCategory(nameof(RollbarLoggerFixture))]
     public class RollbarLoggerFixture
     {
         private IRollbar _logger = null;

--- a/UnitTest.Rollbar/RollbarQueueControllerFixture.cs
+++ b/UnitTest.Rollbar/RollbarQueueControllerFixture.cs
@@ -8,7 +8,7 @@ namespace UnitTest.Rollbar
     using System.Threading;
 
     [TestClass]
-    [TestCategory("RollbarQueueControllerFixture")]
+    [TestCategory(nameof(RollbarQueueControllerFixture))]
     public class RollbarQueueControllerFixture
     {
         //private IRollbar _logger = null;

--- a/UnitTest.Rollbar/Serialization/Json/JsonScrubberFixture.cs
+++ b/UnitTest.Rollbar/Serialization/Json/JsonScrubberFixture.cs
@@ -11,7 +11,7 @@ namespace UnitTest.Rollbar.Serialization.Json
     using System.Threading;
 
     [TestClass]
-    [TestCategory("JsonScrubberFixture")]
+    [TestCategory(nameof(JsonScrubberFixture))]
     public class JsonScrubberFixture
     {
         [TestInitialize]


### PR DESCRIPTION
we also will have to add an extra section of documentation:

Blocking vs Non-Blocking Use of the Notifier

As an instrumentation component, the Notifier is designed to have as little impact on the hosting system/application as possible. 
Normally, you would want to use asynchronous logging since it has virtually no instrumentational overhead on your application execution performance at runtime. It has "fire and forget" approach to logging. 
However, in some specific situations, for example, while logging right before exiting an application, you may want to use it synchronously so that the application does not quit before the logging completes.
That is why all the logging methods of this interface imply asynchronous/non-blocking implementation. However, the interface defines the AsBlockingLogger(TimeSpan timeout) method that returns a synchronous implementation of ILogger. This approach allows for easier code refactoring when switching between asynchronous and synchronous uses of the logger.

So, to summarize all the info above, the following call:

logger.Log(ErrorLevel.Error, "test message");

would perform async logging, while this one:

logger.AsBlockingLogger(TimeSpan.FromSeconds(1)).Log(ErrorLevel.Error, "test message");

would perform blocking/synchronous logging with a timeout of 1 second.
In case of the timeout all the blocking log methods throw System.TimeoutException instead of gracefully completing the call. So, you might want to make all the blocking log calls within try-catch block while catching System.TimeoutException specifically to handle a timeout case as you wish.
