### PR TITLE
v1.5.2 release candidate

### DIFF
--- a/Rollbar/AspNetCore/RollbarLogger.cs
+++ b/Rollbar/AspNetCore/RollbarLogger.cs
@@ -126,15 +126,19 @@ namespace Rollbar.AspNetCore
             }
 
             Rollbar.DTOs.Body payloadBody = null;
-            if (!string.IsNullOrWhiteSpace(message))
+            if (exception != null)
+            {
+                payloadBody = new DTOs.Body(exception);
+            }
+            else if (!string.IsNullOrWhiteSpace(message))
             {
                 payloadBody = new DTOs.Body(new DTOs.Message(message));
             }
             else
             {
-                payloadBody = new DTOs.Body(exception);
+                return; //nothing to report...
             }
-
+            
             Dictionary<string, object> customProperties = new Dictionary<string, object>();
             customProperties.Add(
                 "LogEventID"

--- a/Sample.AspNetCore2.WebApi/Controllers/ValuesController.cs
+++ b/Sample.AspNetCore2.WebApi/Controllers/ValuesController.cs
@@ -28,10 +28,30 @@
         {
             this._logger.LogCritical(nameof(ValuesController) + ".Get() is called...");
 
+            try
+            {
+                int level = 0;
+                this.FakeExceptionCallStack(ref level);
+            }
+            catch(Exception ex)
+            {
+                this._logger.Log(logLevel: LogLevel.Critical, exception: ex, message: "Got one!");
+            }
+
             //// Let's simulate an unhandled exception:
             throw new Exception("AspNetCore2.WebApi sample: Unhandled exception within the ValueController");
 
             return new string[] { "value1", "value2" };
+        }
+
+        private void FakeExceptionCallStack(ref int level)
+        {
+            level++;
+            if (level == 5)
+            {
+                throw new Exception("Outer handled exception", new NullReferenceException("Inner handled exception"));
+            }
+            this.FakeExceptionCallStack(ref level);
         }
 
         private void Rollbar_InternalEvent(object sender, Rollbar.RollbarEventArgs e)

--- a/SolutionCommon.csproj
+++ b/SolutionCommon.csproj
@@ -8,20 +8,12 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     -->
 
-    <NotifierVersion>1.5.1</NotifierVersion>
+    <NotifierVersion>1.5.2</NotifierVersion>
     <PackageReleaseNotes>
 
       New features, enhancements and fixes:
 
-      - resolve #164: Refactoring: consolidate .Net DateTime-to/from-UnixTimestamp conversions within a utility class
-      - resolve #161: Rollbar Asp.Net Core middleware: auto-capture a NetworkTelemetry event based on the HTTP request processed by the middleware
-      - resolve #160: Capture CPU architecture as a new data field within Client/Server elements of the payload
-      - resolve #158: Implement proper hosting OS detection under .Net Core
-      - resolve #157: Refactoring: extract deployment related functionality of RollbarClient into RollbarDeployClient
-      - resolve #156: Performance: reuse the same HttpClient instance whenever possible
-      - resolve #155: Samples: Update Xamarin sample's dependencies
-      - resolve #154: UX: Add type discovery and casting with proper overload call to all the RollbarLogger's methods that accept object as their first argument
-
+      - resolve #165: AspNetCore2.WebApi _logger.LogError(exception, "bla"); doesn't send the exception to rollbar
 
     </PackageReleaseNotes>
 


### PR DESCRIPTION
- resolve #165: AspNetCore2.WebApi _logger.LogError(exception, "bla"); doesn't send the exception to rollbar