### PR TITLE
Make Rollbar.NET available as NLog target

### DIFF
--- a/Rollbar.PlugIns.Log4net/Rollbar.PlugIns.Log4net.csproj
+++ b/Rollbar.PlugIns.Log4net/Rollbar.PlugIns.Log4net.csproj
@@ -1,7 +1,21 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+
+    <Version>$(NotifierVersion)</Version>
+    <AssemblyVersion>$(NotifierVersion)</AssemblyVersion>
+    <FileVersion>$(NotifierVersion)</FileVersion>
+
+    <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
+    <Copyright>Copyright (c) $(CurrentYear) Rollbar Inc</Copyright>
+    <Company>Rollbar Inc</Company>
+    <PackageTags>log4net;rollbar;logging</PackageTags>
+    <PackageIconUrl>https://raw.githubusercontent.com/rollbar/Rollbar.NET/master/rollbar-logo.png</PackageIconUrl>
+    <PackageProjectUrl>https://github.com/rollbar/Rollbar.NET</PackageProjectUrl>
+    <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/rollbar/Rollbar.NET.git</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Rollbar.PlugIns.Log4net/RollbarAppender.cs
+++ b/Rollbar.PlugIns.Log4net/RollbarAppender.cs
@@ -4,7 +4,6 @@
     using System.Collections.Generic;
     using log4net.Appender;
     using log4net.Core;
-    using Rollbar.NetCore;
 
     /// <summary>
     /// Class RollbarAppender.
@@ -140,9 +139,10 @@
         public RollbarAppender()
         {
             RollbarConfig rollbarConfig = new RollbarConfig("just_a_seed_value");
-            AppSettingsUtil.LoadAppSettings(ref rollbarConfig);
+#if NETSTANDARD
+            Rollbar.NetCore.AppSettingsUtil.LoadAppSettings(ref rollbarConfig);
+#endif
             this._rollbarConfig = rollbarConfig;
-
             RollbarFactory.CreateProper(
                 this._rollbarConfig,
                 TimeSpan.FromSeconds(rollbarTimeoutSeconds),

--- a/Rollbar.PlugIns.NLog/Rollbar.PlugIns.NLog.csproj
+++ b/Rollbar.PlugIns.NLog/Rollbar.PlugIns.NLog.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
 
     <Version>$(NotifierVersion)</Version>
     <AssemblyVersion>$(NotifierVersion)</AssemblyVersion>
@@ -10,7 +10,7 @@
     <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
     <Copyright>Copyright (c) $(CurrentYear) Rollbar Inc</Copyright>
     <Company>Rollbar Inc</Company>
-    <PackageTags>log4net;rollbar;logging</PackageTags>
+    <PackageTags>nlog;nlog-target;rollbar;logging</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/rollbar/Rollbar.NET/master/rollbar-logo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/rollbar/Rollbar.NET</PackageProjectUrl>
     <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="NLog" Version="4.5.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Rollbar.PlugIns.NLog/RollbarTarget.cs
+++ b/Rollbar.PlugIns.NLog/RollbarTarget.cs
@@ -1,0 +1,121 @@
+﻿namespace Rollbar.PlugIns.NLog
+{
+    using System;
+    using System.Collections.Generic;
+    using global::NLog;
+    using global::NLog.Config;
+    using global::NLog.Targets;
+
+    /// <summary>
+    /// Class RollbarTarget for NLog.
+    /// </summary>
+    [Target("Rollbar.PlugIns.NLog")]
+    public class RollbarTarget : TargetWithContext
+    {
+        [NLogConfigurationIgnoreProperty]
+        public RollbarConfig RollbarConfig { get; }
+
+        /// <summary>
+        /// Configure to avoid out-of-order enqueuing of LogEvents, because of Task-race-conditions
+        /// </summary>
+        public TimeSpan? BlockingLoggingTimeout { get; set; }
+
+        /// <summary>
+        /// The Rollbar asynchronous logger
+        /// </summary>
+        private Rollbar.IAsyncLogger _rollbarAsyncLogger;
+
+        /// <summary>
+        /// The Rollbar logger
+        /// </summary>
+        private Rollbar.ILogger _rollbarLogger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RollbarTarget"/> class.
+        /// </summary>
+        public RollbarTarget()
+            :this(CreateDefaultRollbarConfig())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RollbarTarget"/> class.
+        /// </summary>
+        public RollbarTarget(RollbarConfig rollbarConfig)
+        {
+            RollbarConfig = rollbarConfig;
+            OptimizeBufferReuse = true;
+            Layout = "${message}";
+        }
+
+        protected override void InitializeTarget()
+        {
+            RollbarFactory.CreateProper(RollbarConfig, BlockingLoggingTimeout, out _rollbarAsyncLogger, out _rollbarLogger);
+            base.InitializeTarget();
+        }
+
+        protected override void Write(LogEventInfo logEvent)
+        {
+            if (!LevelMapper.TryGetValue(logEvent.Level, out ErrorLevel rollbarLogLevel))
+                rollbarLogLevel = ErrorLevel.Debug;
+
+            DTOs.Body rollbarBody = null;
+            if (logEvent.Exception != null)
+            {
+                rollbarBody = new DTOs.Body(logEvent.Exception);
+            }
+            else
+            {
+                var formattedMessage = RenderLogEvent(Layout, logEvent);
+                rollbarBody = new DTOs.Body(new DTOs.Message(formattedMessage));
+            }
+
+            IDictionary<string, object> custom = GetAllProperties(logEvent);
+            DTOs.Data rollbarData = new DTOs.Data(RollbarConfig, rollbarBody, custom)
+            {
+                Level = rollbarLogLevel
+            };
+
+            ReportToRollbar(rollbarData);
+        }
+
+        /// <summary>
+        /// Reports to Rollbar.
+        /// </summary>
+        /// <param name="rollbarData">The Rollbar data.</param>
+        private void ReportToRollbar(DTOs.Data rollbarData)
+        {
+            if (_rollbarAsyncLogger != null)
+            {
+                _rollbarAsyncLogger.Log(rollbarData);
+            }
+            else if (_rollbarLogger != null)
+            {
+                _rollbarLogger.Log(rollbarData);
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="RollbarConfig"/> from app.config (NetFramework) / appsettings.json (NetCore)
+        /// </summary>
+        private static RollbarConfig CreateDefaultRollbarConfig()
+        {
+            var rollbarConfig = new RollbarConfig("just_a_seed_value");
+#if NETSTANDARD
+            Rollbar.NetCore.AppSettingsUtil.LoadAppSettings(ref rollbarConfig);
+#endif
+            return rollbarConfig;
+        }
+
+        private static readonly Dictionary<LogLevel, ErrorLevel> LevelMapper = new Dictionary<LogLevel, ErrorLevel>
+        {
+            // Map NLog levels to Rollbar ErrorLevel
+            { LogLevel.Fatal, ErrorLevel.Critical },
+            { LogLevel.Error, ErrorLevel.Error },
+            { LogLevel.Warn, ErrorLevel.Warning },
+            { LogLevel.Info, ErrorLevel.Info },
+            { LogLevel.Debug, ErrorLevel.Debug },
+            { LogLevel.Trace, ErrorLevel.Debug },
+        };
+    }
+}

--- a/Rollbar.sln
+++ b/Rollbar.sln
@@ -16,7 +16,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitTest.Rollbar", "UnitTes
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rollbar.PlugIns.Serilog", "Rollbar.PlugIns.Serilog\Rollbar.PlugIns.Serilog.csproj", "{269A0ECE-643A-49F2-BDB0-A5762729A819}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rollbar.PlugIns.Log4net", "Rollbar.PlugIns.Log4net\Rollbar.PlugIns.Log4net.csproj", "{06252A00-27C7-41C7-8922-56DAF70F50DC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rollbar.PlugIns.Log4net", "Rollbar.PlugIns.Log4net\Rollbar.PlugIns.Log4net.csproj", "{06252A00-27C7-41C7-8922-56DAF70F50DC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rollbar.Plugins.NLog", "Rollbar.Plugins.NLog\Rollbar.Plugins.NLog.csproj", "{86E63E3F-828C-4F80-804B-16CF1CF407D2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -49,6 +51,12 @@ Global
 		{06252A00-27C7-41C7-8922-56DAF70F50DC}.Instrumented|Any CPU.Build.0 = Debug|Any CPU
 		{06252A00-27C7-41C7-8922-56DAF70F50DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{06252A00-27C7-41C7-8922-56DAF70F50DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86E63E3F-828C-4F80-804B-16CF1CF407D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86E63E3F-828C-4F80-804B-16CF1CF407D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86E63E3F-828C-4F80-804B-16CF1CF407D2}.Instrumented|Any CPU.ActiveCfg = Debug|Any CPU
+		{86E63E3F-828C-4F80-804B-16CF1CF407D2}.Instrumented|Any CPU.Build.0 = Debug|Any CPU
+		{86E63E3F-828C-4F80-804B-16CF1CF407D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86E63E3F-828C-4F80-804B-16CF1CF407D2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Sample.PlugIns.NLog.sln
+++ b/Sample.PlugIns.NLog.sln
@@ -1,0 +1,58 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2036
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "RollbarNLog", "RollbarNLog", "{3635FA93-6994-4CE4-9923-BF330DF1A439}"
+	ProjectSection(SolutionItems) = preProject
+		SolutionCommon.csproj = SolutionCommon.csproj
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rollbar", "Rollbar\Rollbar.csproj", "{FA70AC31-5CD9-4947-8D5F-624D9A1FB510}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rollbar.PlugIns.NLog", "Rollbar.PlugIns.NLog\Rollbar.PlugIns.NLog.csproj", "{2F38C4D8-6B95-4458-9028-C0C2F5646C84}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleApp", "Sample.PlugIns.NLog\ConsoleApp\ConsoleApp.csproj", "{3ABEF49C-DEFD-40D3-8461-37D2B967DB8D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionItems", "{7244094A-1028-47E0-BCD4-4837651428AA}"
+	ProjectSection(SolutionItems) = preProject
+		Sample.PlugIns.NLog\ReadMe.md = Sample.PlugIns.NLog\ReadMe.md
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Instrumented|Any CPU = Instrumented|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FA70AC31-5CD9-4947-8D5F-624D9A1FB510}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FA70AC31-5CD9-4947-8D5F-624D9A1FB510}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FA70AC31-5CD9-4947-8D5F-624D9A1FB510}.Instrumented|Any CPU.ActiveCfg = Instrumented|Any CPU
+		{FA70AC31-5CD9-4947-8D5F-624D9A1FB510}.Instrumented|Any CPU.Build.0 = Instrumented|Any CPU
+		{FA70AC31-5CD9-4947-8D5F-624D9A1FB510}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FA70AC31-5CD9-4947-8D5F-624D9A1FB510}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F38C4D8-6B95-4458-9028-C0C2F5646C84}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F38C4D8-6B95-4458-9028-C0C2F5646C84}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F38C4D8-6B95-4458-9028-C0C2F5646C84}.Instrumented|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F38C4D8-6B95-4458-9028-C0C2F5646C84}.Instrumented|Any CPU.Build.0 = Debug|Any CPU
+		{2F38C4D8-6B95-4458-9028-C0C2F5646C84}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F38C4D8-6B95-4458-9028-C0C2F5646C84}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3ABEF49C-DEFD-40D3-8461-37D2B967DB8D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3ABEF49C-DEFD-40D3-8461-37D2B967DB8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3ABEF49C-DEFD-40D3-8461-37D2B967DB8D}.Instrumented|Any CPU.ActiveCfg = Debug|Any CPU
+		{3ABEF49C-DEFD-40D3-8461-37D2B967DB8D}.Instrumented|Any CPU.Build.0 = Debug|Any CPU
+		{3ABEF49C-DEFD-40D3-8461-37D2B967DB8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3ABEF49C-DEFD-40D3-8461-37D2B967DB8D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{FA70AC31-5CD9-4947-8D5F-624D9A1FB510} = {3635FA93-6994-4CE4-9923-BF330DF1A439}
+		{2F38C4D8-6B95-4458-9028-C0C2F5646C84} = {3635FA93-6994-4CE4-9923-BF330DF1A439}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {AB9E5CFE-0437-4312-99E5-1EBF60FB8157}
+	EndGlobalSection
+EndGlobal

--- a/Sample.PlugIns.NLog/ConsoleApp/ConsoleApp.csproj
+++ b/Sample.PlugIns.NLog/ConsoleApp/ConsoleApp.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Rollbar.PlugIns.NLog\Rollbar.PlugIns.NLog.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="NLog.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Sample.PlugIns.NLog/ConsoleApp/NLog.config
+++ b/Sample.PlugIns.NLog/ConsoleApp/NLog.config
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" throwConfigExceptions="true" internalLogToConsole="true" internalLogLevel="Warn">
+
+  <extensions>
+    <add assembly="Rollbar.PlugIns.NLog"/>
+  </extensions>
+
+  <targets>
+    <target name="logrollbar" xsi:type="Rollbar.PlugIns.NLog">
+      <contextproperty name="HostName" layout="${machinename}" />
+    </target>
+    <target name="logconsole" xsi:type="Console" />
+  </targets>
+
+  <rules>
+    <logger name="*" minlevel="Info" writeTo="logconsole" />
+    <logger name="*" minlevel="Info" writeTo="logrollbar" />
+  </rules>
+</nlog>

--- a/Sample.PlugIns.NLog/ConsoleApp/Program.cs
+++ b/Sample.PlugIns.NLog/ConsoleApp/Program.cs
@@ -1,0 +1,27 @@
+﻿namespace ConsoleApp
+{
+    using System;
+    using NLog;
+
+    class Program
+    {
+        // Initialize a log4net's ILog instance:
+        private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+        static void Main(string[] args)
+        {
+            // an example of an informational log via log4net:
+            Log.Info("Hello world from NLog!");
+
+            try
+            {
+                throw new ApplicationException("Oy vey via NLog!");
+            }
+            catch(Exception ex)
+            {
+                // an example of an error log via NLog:
+                Log.Error("Just FYI...", ex);
+            }
+        }
+    }
+}

--- a/Sample.PlugIns.NLog/ConsoleApp/appsettings.json
+++ b/Sample.PlugIns.NLog/ConsoleApp/appsettings.json
@@ -1,0 +1,20 @@
+﻿{
+  "Rollbar": {
+    "AccessToken": "17965fa5041749b6bf7095a190001ded",
+    "Environment": "RollbarNetSamples",
+    "Enabled": true,
+    "MaxReportsPerMinute": 30,
+    "ReportingQueueDepth": 120,
+    "LogLevel": "Debug",
+    "ScrubFields": [
+      "ThePassword",
+      "TheSecret"
+    ],
+    "Person": {
+      "UserName": "jbond",
+      "id":  "JBOND"
+    },
+    "PersonDataCollectionPolicies": "Username, Email",
+    "IpAddressCollectionPolicy": "CollectAnonymized"
+  },
+}

--- a/Sample.PlugIns.NLog/ReadMe.md
+++ b/Sample.PlugIns.NLog/ReadMe.md
@@ -1,0 +1,34 @@
+# Sample: Rollbar.NET via NLog
+
+This example demonstrates how to integrate Rollbar.NET within an application that already uses NLog for its logging/tracing purposes 
+and have all (or some of) its logs/traces forwarded/reported to the Rollbar API Service/Dashboard.
+
+This example updates an existing .NET Core console application to support Rollbar capabilities (with no code changes or product re-build required). 
+However, very similar approach can be taken with any .NET Full Framework based application. You will just have to configure Rollbar.NET notifier within 
+the app.config file instead of the appsettings.config file.
+
+## Starting Point
+
+In this example we have a very simple .NET Core console application that already made use of NLog to log informational and error traces.
+The NLog was custom configured using NLog.config that included use of NLog Console.
+
+## Adding Logs Forwarding to the Rollbar Dashboard
+
+- Add/modify the appsettings.json application configuration file to include Rollbar specific configuration options.
+- Drop Rollbar.dll and Rollbar.PlugIns.NLog.dll side by side with the application executable file.
+- Modify the  NLog.config to include the RollbarAppender.
+- Restart your application to have NLog logs forwarded to the Rollbar Dashboard. 
+
+NOTE:
+In this example, we actually included the Rollbar and Rollbar.PlugIns.NLog projects within the sample solution and referenced the projects from the ConsoleApp project.
+It was done to facilitate debugging of the sample and can be omitted if you just drop expected Rollbar.dll and Rollbar.PlugIns.NLog.dll files side by side with the 
+application executable file as described in the steps above.
+
+## Done!
+
+Have fun taking advantages for Rollbar Dashboard while monitoring behavior of your products without having to recompile them (assuming you already used NLog prior to 
+adding the Rollbar support to your products)!
+
+Here is an example of an error log from this sample rendered within the Rollbar Dashboard:
+https://rollbar.com/Rollbar/Rollbar.Net/items/612/occurrences/59671813374/
+


### PR DESCRIPTION
And prepare for having Rollbar.PlugIns.Log4net, Rollbar.PlugIns.Serilog and Rollbar.PlugIns.NLog as nuget-packages.

Btw. any reason why the enqueue operation is performed using an async Task, which is only cpu-bound? There is a huge overhead from creating a Task as it requires allocation and transfer of context state to new thread. Suddenly LogEvents can come out of order because the tasks are not using ContinueWith. If trying to capture state from the HttpContext then it might have become stale and unusable (logging garbage)