### PR TITLE
v2.1.0 release candidate

### DIFF
--- a/Rollbar.PlugIns.Log4net/RollbarAppender.cs
+++ b/Rollbar.PlugIns.Log4net/RollbarAppender.cs
@@ -16,84 +16,15 @@
         : AppenderSkeleton
         , IAppender
     {
-        /// <summary>
-        /// The rollbar timeout in seconds
-        /// </summary>
-        private const int defaultRollbarTimeoutSeconds = 3;
+        private readonly RollbarPlugInCore _rollbarPlugIn;
 
         /// <summary>
-        /// The custom prefix
+        /// Initializes a new instance of the <see cref="RollbarAppender"/> class.
         /// </summary>
-        private const string prefix = "log4net";
-
-        /// <summary>
-        /// The Rollbar error level by log4net level value
-        /// </summary>
-        private static readonly IDictionary<int, Rollbar.ErrorLevel> rollbarErrorLevelByLog4netLevelValue;
-
-        /// <summary>
-        /// Initializes static members of the <see cref="RollbarAppender"/> class.
-        /// </summary>
-        static RollbarAppender()
+        public RollbarAppender()
+            : this(null, RollbarPlugInCore.DefaultRollbarBlockingTimeout)
         {
-            rollbarErrorLevelByLog4netLevelValue = new Dictionary<int, Rollbar.ErrorLevel>();
-
-            rollbarErrorLevelByLog4netLevelValue.Add(Level.Critical.Value, ErrorLevel.Critical);
-            rollbarErrorLevelByLog4netLevelValue.Add(Level.Emergency.Value, ErrorLevel.Critical);
-            rollbarErrorLevelByLog4netLevelValue.Add(Level.Fatal.Value, ErrorLevel.Critical);
-
-            rollbarErrorLevelByLog4netLevelValue.Add(Level.Error.Value, ErrorLevel.Error);
-
-            rollbarErrorLevelByLog4netLevelValue.Add(Level.Alert.Value, ErrorLevel.Warning);
-            rollbarErrorLevelByLog4netLevelValue.Add(Level.Notice.Value, ErrorLevel.Warning);
-            rollbarErrorLevelByLog4netLevelValue.Add(Level.Warn.Value, ErrorLevel.Warning);
-
-            rollbarErrorLevelByLog4netLevelValue.Add(Level.Info.Value, ErrorLevel.Info);
-
-            rollbarErrorLevelByLog4netLevelValue.Add(Level.All.Value, ErrorLevel.Debug);
-            rollbarErrorLevelByLog4netLevelValue.Add(Level.Off.Value, ErrorLevel.Debug);
-
-            // NOTE: the Fine, Finer and Finest log4net levels have their values corresponding to 
-            // following three log4net levels: Verbose, Trace, Debug. Hence, let's count them only once:
-            //rollbarErrorLevelByLog4netLevelValue.Add(Level.Fine.Value, ErrorLevel.Debug);
-            //rollbarErrorLevelByLog4netLevelValue.Add(Level.Finer.Value, ErrorLevel.Debug);
-            //rollbarErrorLevelByLog4netLevelValue.Add(Level.Finest.Value, ErrorLevel.Debug);
-            rollbarErrorLevelByLog4netLevelValue.Add(Level.Verbose.Value, ErrorLevel.Debug);
-            rollbarErrorLevelByLog4netLevelValue.Add(Level.Trace.Value, ErrorLevel.Debug);
-            rollbarErrorLevelByLog4netLevelValue.Add(Level.Debug.Value, ErrorLevel.Debug);
-
-            // NOTE: the Log4Net_Debug log4net level  has its value corresponding to the Emergency level
-            // that is already accounted for above:
-            //rollbarErrorLevelByLog4netLevelValue.Add(Level.Log4Net_Debug.Value, ErrorLevel.Debug);
         }
-
-        /// <summary>
-        /// Translates the specified log4net level.
-        /// </summary>
-        /// <param name="log4netLevel">The log4net level.</param>
-        /// <returns>ErrorLevel.</returns>
-        private static ErrorLevel Translate(Level log4netLevel)
-        {
-            if (rollbarErrorLevelByLog4netLevelValue.TryGetValue(log4netLevel.Value, out ErrorLevel rollbarErrorLevel))
-            {
-                return rollbarErrorLevel;
-            }
-
-            return ErrorLevel.Debug;
-        }
-
-        /// <summary>
-        /// The Rollbar configuration
-        /// </summary>
-        private readonly Rollbar.IRollbarConfig _rollbarConfig;
-        /// <summary>
-        /// The Rollbar asynchronous logger
-        /// </summary>
-        private readonly Rollbar.IAsyncLogger _rollbarAsyncLogger;
-        /// <summary>
-        /// The Rollbar logger
-        /// </summary>
-        private readonly Rollbar.ILogger _rollbarLogger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RollbarAppender"/> class.
@@ -107,8 +38,8 @@
             TimeSpan? rollbarBlockingLoggingTimeout
             )
             : this(
-                  new RollbarConfig(rollbarAccessToken) { Environment = rollbarEnvironment, }
-                  , rollbarBlockingLoggingTimeout
+                  RollbarPlugInCore.CreateConfig(rollbarAccessToken: rollbarAccessToken, rollbarEnvironment: rollbarEnvironment),
+                  rollbarBlockingLoggingTimeout
                   )
         {
         }
@@ -123,32 +54,7 @@
             TimeSpan? rollbarBlockingLoggingTimeout
             )
         {
-            this._rollbarConfig = rollbarConfig;
-
-            RollbarFactory.CreateProper(
-                this._rollbarConfig,
-                rollbarBlockingLoggingTimeout,
-                out this._rollbarAsyncLogger,
-                out this._rollbarLogger
-                );
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RollbarAppender"/> class.
-        /// </summary>
-        public RollbarAppender()
-        {
-            RollbarConfig rollbarConfig = new RollbarConfig("just_a_seed_value");
-#if NETSTANDARD
-            Rollbar.NetCore.AppSettingsUtil.LoadAppSettings(ref rollbarConfig);
-#endif
-            this._rollbarConfig = rollbarConfig;
-            RollbarFactory.CreateProper(
-                this._rollbarConfig,
-                TimeSpan.FromSeconds(defaultRollbarTimeoutSeconds),
-                out this._rollbarAsyncLogger,
-                out this._rollbarLogger
-                );
+            this._rollbarPlugIn = new RollbarPlugInCore(rollbarConfig, rollbarBlockingLoggingTimeout);
         }
 
         /// <summary>
@@ -156,8 +62,7 @@
         /// </summary>
         protected override void OnClose()
         {
-            (this._rollbarAsyncLogger as IDisposable)?.Dispose();
-            (this._rollbarLogger as IDisposable)?.Dispose();
+            this._rollbarPlugIn.Dispose();
 
             base.OnClose();
         }
@@ -168,72 +73,10 @@
         /// <param name="loggingEvent">The logging event.</param>
         protected override void Append(LoggingEvent loggingEvent)
         {
-            if (loggingEvent == null)
+            if (loggingEvent != null)
             {
-                return;
-            }
-
-            ErrorLevel rollbarLogLevel = Translate(loggingEvent.Level);
-
-            string message = loggingEvent.RenderedMessage;
-
-            DTOs.Body rollbarBody = null;
-            if (loggingEvent.ExceptionObject != null)
-            {
-                rollbarBody = new DTOs.Body(loggingEvent.ExceptionObject);
-            }
-            else
-            {
-                rollbarBody = new DTOs.Body(new DTOs.Message(message));
-            }
-
-            int customCapacity = 50;
-            IDictionary<string, object> custom = new Dictionary<string, object>(customCapacity);
-            custom[prefix] = loggingEvent.GetLoggingEventData();
-
-            DTOs.Data rollbarData = new DTOs.Data(this._rollbarConfig, rollbarBody, custom)
-            {
-                Level = rollbarLogLevel
-            };
-
-            this.ReportToRollbar(rollbarData);
-        }
-
-        /// <summary>
-        /// Reports to rollbar.
-        /// </summary>
-        /// <param name="rollbarData">The rollbar data.</param>
-        private void ReportToRollbar(DTOs.Data rollbarData)
-        {
-            if (this._rollbarAsyncLogger != null)
-            {
-                RollbarAppender.ReportToRollbar(this._rollbarAsyncLogger, rollbarData);
-            }
-            else if (this._rollbarLogger != null)
-            {
-                RollbarAppender.ReportToRollbar(this._rollbarLogger, rollbarData);
+                this._rollbarPlugIn.ReportToRollbar(loggingEvent, loggingEvent.Level.Value);
             }
         }
-
-        /// <summary>
-        /// Reports to rollbar.
-        /// </summary>
-        /// <param name="logger">The logger.</param>
-        /// <param name="rollbarData">The rollbar data.</param>
-        private static void ReportToRollbar(Rollbar.ILogger logger, DTOs.Data rollbarData)
-        {
-            logger.Log(rollbarData);
-        }
-
-        /// <summary>
-        /// Reports to rollbar.
-        /// </summary>
-        /// <param name="logger">The logger.</param>
-        /// <param name="rollbarData">The rollbar data.</param>
-        private static void ReportToRollbar(IAsyncLogger logger, DTOs.Data rollbarData)
-        {
-            logger.Log(rollbarData);
-        }
-
     }
 }

--- a/Rollbar.PlugIns.Log4net/RollbarAppender.cs
+++ b/Rollbar.PlugIns.Log4net/RollbarAppender.cs
@@ -1,7 +1,6 @@
 ﻿namespace Rollbar.PlugIns.Log4net
 {
     using System;
-    using System.Collections.Generic;
     using log4net.Appender;
     using log4net.Core;
 

--- a/Rollbar.PlugIns.Log4net/RollbarPlugInCore.cs
+++ b/Rollbar.PlugIns.Log4net/RollbarPlugInCore.cs
@@ -1,0 +1,79 @@
+﻿namespace Rollbar.PlugIns.Log4net
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using log4net.Core;
+
+    internal class RollbarPlugInCore
+        : PlugInCore<int, LoggingEvent>
+    {
+        private const string customPrefix = "log4net";
+
+        private static readonly IDictionary<int, ErrorLevel> rollbarErrorLevelByPlugInErrorLevel = new Dictionary<int, ErrorLevel>
+        {
+            { Level.Critical.Value, ErrorLevel.Critical },
+            { Level.Emergency.Value, ErrorLevel.Critical },
+            { Level.Fatal.Value, ErrorLevel.Critical },
+
+            { Level.Error.Value, ErrorLevel.Error },
+
+            { Level.Alert.Value, ErrorLevel.Warning },
+            { Level.Notice.Value, ErrorLevel.Warning },
+            { Level.Warn.Value, ErrorLevel.Warning },
+
+            { Level.Info.Value, ErrorLevel.Info },
+
+            { Level.All.Value, ErrorLevel.Debug },
+            { Level.Off.Value, ErrorLevel.Debug },
+
+            // NOTE: the Fine, Finer and Finest log4net levels have their values corresponding to 
+            // following three log4net levels: Verbose, Trace, Debug. Hence, let's count them only once:
+            //{ Level.Fine.Value, ErrorLevel.Debug },
+            //{ Level.Finer.Value, ErrorLevel.Debug },
+            //{ Level.Finest.Value, ErrorLevel.Debug },
+            { Level.Verbose.Value, ErrorLevel.Debug },
+            { Level.Trace.Value, ErrorLevel.Debug },
+            { Level.Debug.Value, ErrorLevel.Debug },
+
+            // NOTE: the Log4Net_Debug log4net level  has its value corresponding to the Emergency level
+            // that is already accounted for above:
+            //{ Level.Log4Net_Debug.Value, ErrorLevel.Debug },
+        };
+
+        public RollbarPlugInCore(
+            string rollbarAccessToken,
+            string rollbarEnvironment,
+            TimeSpan? rollbarBlockingLoggingTimeout
+            )
+            : this(
+                  CreateConfig(rollbarAccessToken: rollbarAccessToken, rollbarEnvironment: rollbarEnvironment),
+                  rollbarBlockingLoggingTimeout
+                  )
+        {
+        }
+
+        public RollbarPlugInCore(
+            IRollbarConfig rollbarConfig, 
+            TimeSpan? rollbarBlockingTimeout
+            ) 
+            : base(rollbarErrorLevelByPlugInErrorLevel, customPrefix, rollbarConfig, rollbarBlockingTimeout)
+        {
+        }
+
+        protected override object ExtractCustomProperties(LoggingEvent plugInEventData)
+        {
+            return plugInEventData.GetLoggingEventData();
+        }
+
+        protected override Exception ExtractException(LoggingEvent plugInEventData)
+        {
+            return plugInEventData.ExceptionObject;
+        }
+
+        protected override string ExtractMessage(LoggingEvent plugInEventData)
+        {
+            return plugInEventData.RenderedMessage;
+        }
+    }
+}

--- a/Rollbar.PlugIns.Log4net/RollbarPlugInCore.cs
+++ b/Rollbar.PlugIns.Log4net/RollbarPlugInCore.cs
@@ -5,11 +5,22 @@
     using System.Text;
     using log4net.Core;
 
+    /// <summary>
+    /// Class RollbarPlugInCore.
+    /// Implements the <see cref="Rollbar.PlugIns.PlugInCore{System.Int32, log4net.Core.LoggingEvent}" />
+    /// </summary>
+    /// <seealso cref="Rollbar.PlugIns.PlugInCore{System.Int32, log4net.Core.LoggingEvent}" />
     internal class RollbarPlugInCore
         : PlugInCore<int, LoggingEvent>
     {
+        /// <summary>
+        /// The custom prefix
+        /// </summary>
         private const string customPrefix = "log4net";
 
+        /// <summary>
+        /// The rollbar error level by plug in error level
+        /// </summary>
         private static readonly IDictionary<int, ErrorLevel> rollbarErrorLevelByPlugInErrorLevel = new Dictionary<int, ErrorLevel>
         {
             { Level.Critical.Value, ErrorLevel.Critical },
@@ -41,6 +52,12 @@
             //{ Level.Log4Net_Debug.Value, ErrorLevel.Debug },
         };
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RollbarPlugInCore"/> class.
+        /// </summary>
+        /// <param name="rollbarAccessToken">The rollbar access token.</param>
+        /// <param name="rollbarEnvironment">The rollbar environment.</param>
+        /// <param name="rollbarBlockingLoggingTimeout">The rollbar blocking logging timeout.</param>
         public RollbarPlugInCore(
             string rollbarAccessToken,
             string rollbarEnvironment,
@@ -53,6 +70,11 @@
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RollbarPlugInCore"/> class.
+        /// </summary>
+        /// <param name="rollbarConfig">The rollbar configuration.</param>
+        /// <param name="rollbarBlockingTimeout">The rollbar blocking timeout.</param>
         public RollbarPlugInCore(
             IRollbarConfig rollbarConfig, 
             TimeSpan? rollbarBlockingTimeout
@@ -61,16 +83,31 @@
         {
         }
 
+        /// <summary>
+        /// Extracts the custom properties  for a Rollbar payload from the incoming plug-in's data event.
+        /// </summary>
+        /// <param name="plugInEventData">The plug in event data.</param>
+        /// <returns>Usually, either a data structure or a key-value dictionary returned as a System.Object.</returns>
         protected override object ExtractCustomProperties(LoggingEvent plugInEventData)
         {
             return plugInEventData.GetLoggingEventData();
         }
 
+        /// <summary>
+        /// Extracts the exception for a Rollbar payload from the incoming plug-in's data event.
+        /// </summary>
+        /// <param name="plugInEventData">The plug in event data.</param>
+        /// <returns>Exception.</returns>
         protected override Exception ExtractException(LoggingEvent plugInEventData)
         {
             return plugInEventData.ExceptionObject;
         }
 
+        /// <summary>
+        /// Extracts the message for a Rollbar payload from the incoming plug-in's data event.
+        /// </summary>
+        /// <param name="plugInEventData">The plug in event data.</param>
+        /// <returns>System.String.</returns>
         protected override string ExtractMessage(LoggingEvent plugInEventData)
         {
             return plugInEventData.RenderedMessage;

--- a/Rollbar.PlugIns.NLog/Rollbar.PlugIns.NLog.csproj
+++ b/Rollbar.PlugIns.NLog/Rollbar.PlugIns.NLog.csproj
@@ -16,6 +16,8 @@
     <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/rollbar/Rollbar.NET.git</RepositoryUrl>
+    <AssemblyName>Rollbar.PlugIns.NLog</AssemblyName>
+    <RootNamespace>Rollbar.PlugIns.NLog</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Rollbar.PlugIns.NLog/RollbarPlugInCore.cs
+++ b/Rollbar.PlugIns.NLog/RollbarPlugInCore.cs
@@ -2,16 +2,25 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Text;
     using global::NLog;
     using Rollbar.PlugIns;
-    using Rollbar.PlugIns.NLog;
 
+    /// <summary>
+    /// Class RollbarPlugInCore.
+    /// Implements the <see cref="Rollbar.PlugIns.PlugInCore{NLog.LogLevel, NLog.LogEventInfo}" />
+    /// </summary>
+    /// <seealso cref="Rollbar.PlugIns.PlugInCore{NLog.LogLevel, NLog.LogEventInfo}" />
     internal class RollbarPlugInCore
         : PlugInCore<LogLevel, LogEventInfo>
     {
+        /// <summary>
+        /// The custom prefix
+        /// </summary>
         private const string customPrefix = "nlog";
 
+        /// <summary>
+        /// The rollbar error level by plug in error level
+        /// </summary>
         private static readonly IDictionary<LogLevel, ErrorLevel> rollbarErrorLevelByPlugInErrorLevel =
             new Dictionary<LogLevel, ErrorLevel> {
 
@@ -23,8 +32,18 @@
                 { LogLevel.Trace, ErrorLevel.Debug },
             };
 
+        /// <summary>
+        /// The rollbar target
+        /// </summary>
         private readonly RollbarTarget _rollbarTarget;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RollbarPlugInCore"/> class.
+        /// </summary>
+        /// <param name="rollbarAccessToken">The rollbar access token.</param>
+        /// <param name="rollbarEnvironment">The rollbar environment.</param>
+        /// <param name="rollbarBlockingLoggingTimeout">The rollbar blocking logging timeout.</param>
+        /// <param name="rollbarTarget">The rollbar target.</param>
         public RollbarPlugInCore(
             string rollbarAccessToken,
             string rollbarEnvironment,
@@ -39,6 +58,12 @@
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RollbarPlugInCore"/> class.
+        /// </summary>
+        /// <param name="rollbarConfig">The rollbar configuration.</param>
+        /// <param name="rollbarBlockingTimeout">The rollbar blocking timeout.</param>
+        /// <param name="rollbarTarget">The rollbar target.</param>
         public RollbarPlugInCore(
             IRollbarConfig rollbarConfig,
             TimeSpan? rollbarBlockingTimeout,
@@ -49,16 +74,31 @@
             this._rollbarTarget = rollbarTarget;
         }
 
+        /// <summary>
+        /// Extracts the custom properties  for a Rollbar payload from the incoming plug-in's data event.
+        /// </summary>
+        /// <param name="plugInEventData">The plug in event data.</param>
+        /// <returns>Usually, either a data structure or a key-value dictionary returned as a System.Object.</returns>
         protected override object ExtractCustomProperties(LogEventInfo plugInEventData)
         {
             return this._rollbarTarget.GetEventProperties(plugInEventData);
         }
 
+        /// <summary>
+        /// Extracts the exception for a Rollbar payload from the incoming plug-in's data event.
+        /// </summary>
+        /// <param name="plugInEventData">The plug in event data.</param>
+        /// <returns>Exception.</returns>
         protected override Exception ExtractException(LogEventInfo plugInEventData)
         {
             return plugInEventData.Exception;
         }
 
+        /// <summary>
+        /// Extracts the message for a Rollbar payload from the incoming plug-in's data event.
+        /// </summary>
+        /// <param name="plugInEventData">The plug in event data.</param>
+        /// <returns>System.String.</returns>
         protected override string ExtractMessage(LogEventInfo plugInEventData)
         {
             return this._rollbarTarget.GetFormattedEventMessage(plugInEventData);

--- a/Rollbar.PlugIns.NLog/RollbarPlugInCore.cs
+++ b/Rollbar.PlugIns.NLog/RollbarPlugInCore.cs
@@ -1,0 +1,67 @@
+﻿namespace Rollbar.PlugIns.NLog
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using global::NLog;
+    using Rollbar.PlugIns;
+    using Rollbar.PlugIns.NLog;
+
+    internal class RollbarPlugInCore
+        : PlugInCore<LogLevel, LogEventInfo>
+    {
+        private const string customPrefix = "nlog";
+
+        private static readonly IDictionary<LogLevel, ErrorLevel> rollbarErrorLevelByPlugInErrorLevel =
+            new Dictionary<LogLevel, ErrorLevel> {
+
+                { LogLevel.Fatal, ErrorLevel.Critical },
+                { LogLevel.Error, ErrorLevel.Error },
+                { LogLevel.Warn, ErrorLevel.Warning },
+                { LogLevel.Info, ErrorLevel.Info },
+                { LogLevel.Debug, ErrorLevel.Debug },
+                { LogLevel.Trace, ErrorLevel.Debug },
+            };
+
+        private readonly RollbarTarget _rollbarTarget;
+
+        public RollbarPlugInCore(
+            string rollbarAccessToken,
+            string rollbarEnvironment,
+            TimeSpan? rollbarBlockingLoggingTimeout,
+            RollbarTarget rollbarTarget
+            )
+            : this(
+                  CreateConfig(rollbarAccessToken: rollbarAccessToken, rollbarEnvironment: rollbarEnvironment),
+                  rollbarBlockingLoggingTimeout,
+                  rollbarTarget
+                  )
+        {
+        }
+
+        public RollbarPlugInCore(
+            IRollbarConfig rollbarConfig,
+            TimeSpan? rollbarBlockingTimeout,
+            RollbarTarget rollbarTarget
+            )
+            : base(rollbarErrorLevelByPlugInErrorLevel, customPrefix, rollbarConfig, rollbarBlockingTimeout)
+        {
+            this._rollbarTarget = rollbarTarget;
+        }
+
+        protected override object ExtractCustomProperties(LogEventInfo plugInEventData)
+        {
+            return this._rollbarTarget.GetEventProperties(plugInEventData);
+        }
+
+        protected override Exception ExtractException(LogEventInfo plugInEventData)
+        {
+            return plugInEventData.Exception;
+        }
+
+        protected override string ExtractMessage(LogEventInfo plugInEventData)
+        {
+            return this._rollbarTarget.GetFormattedEventMessage(plugInEventData);
+        }
+    }
+}

--- a/Rollbar.PlugIns.NLog/RollbarTarget.cs
+++ b/Rollbar.PlugIns.NLog/RollbarTarget.cs
@@ -5,6 +5,7 @@
     using global::NLog;
     using global::NLog.Config;
     using global::NLog.Targets;
+    using Rollbar.NetStandard;
 
     /// <summary>
     /// Class RollbarTarget for NLog.
@@ -14,11 +15,18 @@
     {
         private readonly RollbarPlugInCore _rollbarPlugIn;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RollbarTarget"/> class.
+        /// </summary>
         public RollbarTarget()
             :this(CreateDefaultRollbarConfig())
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RollbarTarget"/> class.
+        /// </summary>
+        /// <param name="rollbarConfig">The rollbar configuration.</param>
         public RollbarTarget(IRollbarConfig rollbarConfig)
         {
             OptimizeBufferReuse = true;
@@ -28,6 +36,11 @@
                 new RollbarPlugInCore(rollbarConfig, RollbarPlugInCore.DefaultRollbarBlockingTimeout, this);
         }
 
+        /// <summary>
+        /// Writes logging event to the log target. Must be overridden in inheriting
+        /// classes.
+        /// </summary>
+        /// <param name="logEvent">Logging event to be written out.</param>
         protected override void Write(LogEventInfo logEvent)
         {
             if (logEvent != null)
@@ -36,27 +49,32 @@
             }
         }
 
+        /// <summary>
+        /// Gets the formatted event message.
+        /// </summary>
+        /// <param name="logEventInfo">The log event information.</param>
+        /// <returns>System.String.</returns>
         public string GetFormattedEventMessage(LogEventInfo logEventInfo)
         {
             return RenderLogEvent(Layout, logEventInfo);
         }
 
+        /// <summary>
+        /// Gets the event properties.
+        /// </summary>
+        /// <param name="logEventInfo">The log event information.</param>
+        /// <returns>IDictionary&lt;System.String, System.Object&gt;.</returns>
         public IDictionary<string, object> GetEventProperties(LogEventInfo logEventInfo)
         {
             return this.GetAllProperties(logEventInfo);
         }
 
-
         /// <summary>
         /// Initializes a new <see cref="RollbarConfig"/> from app.config (NetFramework) / appsettings.json (NetCore)
         /// </summary>
-        private static RollbarConfig CreateDefaultRollbarConfig()
+        private static IRollbarConfig CreateDefaultRollbarConfig()
         {
-            var rollbarConfig = new RollbarConfig("just_a_seed_value");
-#if NETSTANDARD
-            Rollbar.NetCore.AppSettingsUtil.LoadAppSettings(ref rollbarConfig);
-#endif
-            return rollbarConfig;
+            return RollbarConfigUtil.LoadRollbarConfig();
         }
     }
 }

--- a/Rollbar.PlugIns.NLog/RollbarTarget.cs
+++ b/Rollbar.PlugIns.NLog/RollbarTarget.cs
@@ -12,107 +12,40 @@
     [Target("Rollbar.PlugIns.NLog")]
     public class RollbarTarget : TargetWithContext
     {
-        /// <summary>
-        /// The rollbar timeout in seconds
-        /// </summary>
-        private const int defaultRollbarTimeoutSeconds = 3;
+        private readonly RollbarPlugInCore _rollbarPlugIn;
 
-        /// <summary>
-        /// The custom prefix
-        /// </summary>
-        private const string prefix = "nlog.";
-
-        [NLogConfigurationIgnoreProperty]
-        public RollbarConfig RollbarConfig { get; }
-
-        /// <summary>
-        /// Configure to allow Rollbar payload delivery within the timeout.
-        /// </summary>
-        public TimeSpan? BlockingLoggingTimeout { get; set; }
-
-        /// <summary>
-        /// The Rollbar asynchronous logger
-        /// </summary>
-        private Rollbar.IAsyncLogger _rollbarAsyncLogger;
-
-        /// <summary>
-        /// The Rollbar logger
-        /// </summary>
-        private Rollbar.ILogger _rollbarLogger;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RollbarTarget"/> class.
-        /// </summary>
         public RollbarTarget()
             :this(CreateDefaultRollbarConfig())
         {
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RollbarTarget"/> class.
-        /// </summary>
-        public RollbarTarget(RollbarConfig rollbarConfig)
+        public RollbarTarget(IRollbarConfig rollbarConfig)
         {
-            this.BlockingLoggingTimeout = TimeSpan.FromSeconds(defaultRollbarTimeoutSeconds);
-            RollbarConfig = rollbarConfig;
             OptimizeBufferReuse = true;
             Layout = "${message}";
-        }
 
-        protected override void InitializeTarget()
-        {
-            RollbarFactory.CreateProper(RollbarConfig, BlockingLoggingTimeout, out _rollbarAsyncLogger, out _rollbarLogger);
-            base.InitializeTarget();
+            this._rollbarPlugIn =
+                new RollbarPlugInCore(rollbarConfig, RollbarPlugInCore.DefaultRollbarBlockingTimeout, this);
         }
 
         protected override void Write(LogEventInfo logEvent)
         {
-            if (!LevelMapper.TryGetValue(logEvent.Level, out ErrorLevel rollbarLogLevel))
+            if (logEvent != null)
             {
-                rollbarLogLevel = ErrorLevel.Debug;
+                this._rollbarPlugIn.ReportToRollbar(logEvent, logEvent.Level);
             }
-
-            DTOs.Body rollbarBody = null;
-            if (logEvent.Exception != null)
-            {
-                rollbarBody = new DTOs.Body(logEvent.Exception);
-            }
-            else
-            {
-                var formattedMessage = RenderLogEvent(Layout, logEvent);
-                rollbarBody = new DTOs.Body(new DTOs.Message(formattedMessage));
-            }
-
-            var nlogProperties = GetAllProperties(logEvent);
-            IDictionary<string, object> custom = new Dictionary<string, object>(nlogProperties.Count);
-            foreach(var property in nlogProperties)
-            {
-                custom[prefix + property.Key] = property.Value;
-            }
-            //IDictionary<string, object> custom = GetAllProperties(logEvent);
-            DTOs.Data rollbarData = new DTOs.Data(RollbarConfig, rollbarBody, custom)
-            {
-                Level = rollbarLogLevel
-            };
-
-            ReportToRollbar(rollbarData);
         }
 
-        /// <summary>
-        /// Reports to Rollbar.
-        /// </summary>
-        /// <param name="rollbarData">The Rollbar data.</param>
-        private void ReportToRollbar(DTOs.Data rollbarData)
+        public string GetFormattedEventMessage(LogEventInfo logEventInfo)
         {
-            if (_rollbarAsyncLogger != null)
-            {
-                _rollbarAsyncLogger.Log(rollbarData);
-            }
-            else if (_rollbarLogger != null)
-            {
-                _rollbarLogger.Log(rollbarData);
-            }
+            return RenderLogEvent(Layout, logEventInfo);
         }
+
+        public IDictionary<string, object> GetEventProperties(LogEventInfo logEventInfo)
+        {
+            return this.GetAllProperties(logEventInfo);
+        }
+
 
         /// <summary>
         /// Initializes a new <see cref="RollbarConfig"/> from app.config (NetFramework) / appsettings.json (NetCore)
@@ -125,16 +58,5 @@
 #endif
             return rollbarConfig;
         }
-
-        private static readonly Dictionary<LogLevel, ErrorLevel> LevelMapper = new Dictionary<LogLevel, ErrorLevel>
-        {
-            // Map NLog levels to Rollbar ErrorLevel
-            { LogLevel.Fatal, ErrorLevel.Critical },
-            { LogLevel.Error, ErrorLevel.Error },
-            { LogLevel.Warn, ErrorLevel.Warning },
-            { LogLevel.Info, ErrorLevel.Info },
-            { LogLevel.Debug, ErrorLevel.Debug },
-            { LogLevel.Trace, ErrorLevel.Debug },
-        };
     }
 }

--- a/Rollbar.PlugIns.Serilog/RollbarPlugInCore.cs
+++ b/Rollbar.PlugIns.Serilog/RollbarPlugInCore.cs
@@ -1,0 +1,89 @@
+﻿namespace Rollbar.PlugIns.Serilog
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using global::Serilog.Events;
+
+    internal class RollbarPlugInCore
+         : PlugInCore<LogEventLevel, LogEvent>
+    {
+        private const string customPrefix = "serilog";
+
+        private static readonly IDictionary<LogEventLevel, ErrorLevel> rollbarErrorLevelByPlugInErrorLevel = 
+            new Dictionary<LogEventLevel, ErrorLevel> {
+
+                { LogEventLevel.Fatal, ErrorLevel.Critical },
+                { LogEventLevel.Error, ErrorLevel.Error },
+                { LogEventLevel.Warning, ErrorLevel.Warning },
+                { LogEventLevel.Information, ErrorLevel.Info },
+                { LogEventLevel.Verbose, ErrorLevel.Debug },
+                { LogEventLevel.Debug, ErrorLevel.Debug },
+            };
+
+        private readonly IFormatProvider _formatProvider;
+
+        public RollbarPlugInCore(
+            string rollbarAccessToken,
+            string rollbarEnvironment,
+            TimeSpan? rollbarBlockingLoggingTimeout,
+            IFormatProvider formatProvider
+            )
+            : this(
+                  CreateConfig(rollbarAccessToken: rollbarAccessToken, rollbarEnvironment: rollbarEnvironment),
+                  rollbarBlockingLoggingTimeout,
+                  formatProvider
+                  )
+        {
+        }
+
+        public RollbarPlugInCore(
+            IRollbarConfig rollbarConfig, 
+            TimeSpan? rollbarBlockingTimeout,
+            IFormatProvider formatProvider
+            ) 
+            : base(rollbarErrorLevelByPlugInErrorLevel, customPrefix, rollbarConfig, rollbarBlockingTimeout)
+        {
+            this._formatProvider = formatProvider;
+        }
+
+        protected override object ExtractCustomProperties(LogEvent plugInEventData)
+        {
+            int customCapacity = 1;
+            if (plugInEventData.Properties != null)
+            {
+                customCapacity += plugInEventData.Properties.Count;
+            }
+            if (plugInEventData.Exception != null)
+            {
+                customCapacity++;
+            }
+
+            IDictionary<string, object> custom = new Dictionary<string, object>(customCapacity);
+            if (plugInEventData.Exception != null)
+            {
+                custom["LogEventRenderedMessage"] = plugInEventData.RenderMessage(this._formatProvider); ;
+            }
+            if (plugInEventData.Properties != null)
+            {
+                foreach (var property in plugInEventData.Properties)
+                {
+                    custom[property.Key] = property.Value.ToString();
+                }
+            }
+            custom["LogEventTimestamp"] = plugInEventData.Timestamp;
+
+            return custom;
+        }
+
+        protected override Exception ExtractException(LogEvent plugInEventData)
+        {
+            return plugInEventData.Exception;
+        }
+
+        protected override string ExtractMessage(LogEvent plugInEventData)
+        {
+            return plugInEventData.RenderMessage(this._formatProvider);
+        }
+    }
+}

--- a/Rollbar.PlugIns.Serilog/RollbarPlugInCore.cs
+++ b/Rollbar.PlugIns.Serilog/RollbarPlugInCore.cs
@@ -2,14 +2,24 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Text;
     using global::Serilog.Events;
 
+    /// <summary>
+    /// Class RollbarPlugInCore.
+    /// Implements the <see cref="Rollbar.PlugIns.PlugInCore{Serilog.Events.LogEventLevel, Serilog.Events.LogEvent}" />
+    /// </summary>
+    /// <seealso cref="Rollbar.PlugIns.PlugInCore{Serilog.Events.LogEventLevel, Serilog.Events.LogEvent}" />
     internal class RollbarPlugInCore
          : PlugInCore<LogEventLevel, LogEvent>
     {
+        /// <summary>
+        /// The custom prefix
+        /// </summary>
         private const string customPrefix = "serilog";
 
+        /// <summary>
+        /// The rollbar error level by plug in error level
+        /// </summary>
         private static readonly IDictionary<LogEventLevel, ErrorLevel> rollbarErrorLevelByPlugInErrorLevel = 
             new Dictionary<LogEventLevel, ErrorLevel> {
 
@@ -21,8 +31,18 @@
                 { LogEventLevel.Debug, ErrorLevel.Debug },
             };
 
+        /// <summary>
+        /// The format provider
+        /// </summary>
         private readonly IFormatProvider _formatProvider;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RollbarPlugInCore"/> class.
+        /// </summary>
+        /// <param name="rollbarAccessToken">The rollbar access token.</param>
+        /// <param name="rollbarEnvironment">The rollbar environment.</param>
+        /// <param name="rollbarBlockingLoggingTimeout">The rollbar blocking logging timeout.</param>
+        /// <param name="formatProvider">The format provider.</param>
         public RollbarPlugInCore(
             string rollbarAccessToken,
             string rollbarEnvironment,
@@ -37,6 +57,12 @@
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RollbarPlugInCore"/> class.
+        /// </summary>
+        /// <param name="rollbarConfig">The rollbar configuration.</param>
+        /// <param name="rollbarBlockingTimeout">The rollbar blocking timeout.</param>
+        /// <param name="formatProvider">The format provider.</param>
         public RollbarPlugInCore(
             IRollbarConfig rollbarConfig, 
             TimeSpan? rollbarBlockingTimeout,
@@ -47,6 +73,11 @@
             this._formatProvider = formatProvider;
         }
 
+        /// <summary>
+        /// Extracts the custom properties  for a Rollbar payload from the incoming plug-in's data event.
+        /// </summary>
+        /// <param name="plugInEventData">The plug in event data.</param>
+        /// <returns>Usually, either a data structure or a key-value dictionary returned as a System.Object.</returns>
         protected override object ExtractCustomProperties(LogEvent plugInEventData)
         {
             int customCapacity = 1;
@@ -76,11 +107,21 @@
             return custom;
         }
 
+        /// <summary>
+        /// Extracts the exception for a Rollbar payload from the incoming plug-in's data event.
+        /// </summary>
+        /// <param name="plugInEventData">The plug in event data.</param>
+        /// <returns>Exception.</returns>
         protected override Exception ExtractException(LogEvent plugInEventData)
         {
             return plugInEventData.Exception;
         }
 
+        /// <summary>
+        /// Extracts the message for a Rollbar payload from the incoming plug-in's data event.
+        /// </summary>
+        /// <param name="plugInEventData">The plug in event data.</param>
+        /// <returns>System.String.</returns>
         protected override string ExtractMessage(LogEvent plugInEventData)
         {
             return plugInEventData.RenderMessage(this._formatProvider);

--- a/Rollbar.PlugIns.Serilog/RollbarSinkExtensions.cs
+++ b/Rollbar.PlugIns.Serilog/RollbarSinkExtensions.cs
@@ -10,7 +10,7 @@
     public static class RollbarSinkExtensions
     {
         /// <summary>
-        /// Rollbars the sink.
+        /// Provides configuration for RollbarSink.
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="rollbarAccessToken">The Rollbar access token.</param>
@@ -34,7 +34,7 @@
         }
 
         /// <summary>
-        /// Rollbars the sink.
+        /// Provides configuration for RollbarSink.
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="rollbarConfig">The Rollbar configuration.</param>

--- a/Rollbar.sln
+++ b/Rollbar.sln
@@ -18,7 +18,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rollbar.PlugIns.Serilog", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rollbar.PlugIns.Log4net", "Rollbar.PlugIns.Log4net\Rollbar.PlugIns.Log4net.csproj", "{06252A00-27C7-41C7-8922-56DAF70F50DC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rollbar.Plugins.NLog", "Rollbar.Plugins.NLog\Rollbar.Plugins.NLog.csproj", "{86E63E3F-828C-4F80-804B-16CF1CF407D2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rollbar.Plugins.NLog", "Rollbar.Plugins.NLog\Rollbar.Plugins.NLog.csproj", "{86E63E3F-828C-4F80-804B-16CF1CF407D2}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "RollbarPlugIns", "RollbarPlugIns", "{A6676C56-D085-4273-9757-B55207C63EFA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -60,6 +62,11 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{269A0ECE-643A-49F2-BDB0-A5762729A819} = {A6676C56-D085-4273-9757-B55207C63EFA}
+		{06252A00-27C7-41C7-8922-56DAF70F50DC} = {A6676C56-D085-4273-9757-B55207C63EFA}
+		{86E63E3F-828C-4F80-804B-16CF1CF407D2} = {A6676C56-D085-4273-9757-B55207C63EFA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AB9E5CFE-0437-4312-99E5-1EBF60FB8157}

--- a/Rollbar/IAsyncLogger.cs
+++ b/Rollbar/IAsyncLogger.cs
@@ -24,7 +24,7 @@
     public interface IAsyncLogger
     {
         /// <summary>
-        /// Ases the blocking logger.
+        /// Returns blocking/synchronous implementation of this ILogger.
         /// </summary>
         /// <param name="timeout">The timeout.</param>
         /// <returns>ILogger.</returns>
@@ -38,7 +38,7 @@
         Task Log(DTOs.Data rollbarData);
 
         /// <summary>
-        /// Logs the specified level.
+        /// Logs using the specified level.
         /// </summary>
         /// <param name="level">The level.</param>
         /// <param name="obj">The object.</param>

--- a/Rollbar/ILogger.cs
+++ b/Rollbar/ILogger.cs
@@ -40,7 +40,7 @@
         ILogger Log(dto.Data data);
  
         /// <summary>
-        /// Logs the specified level.
+        /// Logs using the specified level.
         /// </summary>
         /// <param name="level">The level.</param>
         /// <param name="obj">The object.</param>

--- a/Rollbar/InternalErrorEventArgs.cs
+++ b/Rollbar/InternalErrorEventArgs.cs
@@ -12,11 +12,11 @@
     {
         internal InternalErrorEventArgs(
             RollbarLogger logger,
-            Payload payload,
+            object dataObject,
             System.Exception error,
             string details
             ) 
-            : base(logger, payload)
+            : base(logger, dataObject)
         {
             this.Error = error;
             this.Details = details;

--- a/Rollbar/NetCore/AppSettingsUtil.cs
+++ b/Rollbar/NetCore/AppSettingsUtil.cs
@@ -2,13 +2,14 @@
 
 namespace Rollbar.NetCore
 {
+    using System.Diagnostics;
     using System.IO;
     using Microsoft.Extensions.Configuration;
     using Rollbar.Diagnostics;
     using Rollbar.Telemetry;
 
     /// <summary>
-    /// A utility class aiding in reading in settings from the .NET Core AppSettings files.
+    /// A utility class aiding in reading in settings from the .NET Core appsettings.json files.
     /// </summary>
     public static class AppSettingsUtil
     {
@@ -19,10 +20,17 @@ namespace Rollbar.NetCore
         /// Loads the application settings.
         /// </summary>
         /// <param name="config">The configuration.</param>
-        public static void LoadAppSettings(ref RollbarConfig config)
+        /// <returns>false when the configuration was not found, otherwise true.</returns>
+        public static bool LoadAppSettings(ref RollbarConfig config)
         {
             IConfiguration appSettingsConfig = AppSettingsUtil.LoadAppSettings();
+            if (appSettingsConfig == null)
+            {
+                return false;
+            }
+
             AppSettingsUtil.LoadAppSettings(ref config, appSettingsConfig);
+            return true;
         }
 
         /// <summary>
@@ -30,10 +38,17 @@ namespace Rollbar.NetCore
         /// </summary>
         /// <param name="config">The configuration.</param>
         /// <param name="appSettingsFileName">Name of the application settings file.</param>
-        public static void LoadAppSettings(ref RollbarConfig config, string appSettingsFileName)
+        /// <returns>false when the configuration was not found, otherwise true.</returns>
+        public static bool LoadAppSettings(ref RollbarConfig config, string appSettingsFileName)
         {
             IConfiguration appSettingsConfig = AppSettingsUtil.LoadAppSettings(appSettingsFileName);
+            if (appSettingsConfig == null)
+            {
+                return false;
+            }
+
             AppSettingsUtil.LoadAppSettings(ref config, appSettingsConfig);
+            return true;
         }
 
         /// <summary>
@@ -42,10 +57,17 @@ namespace Rollbar.NetCore
         /// <param name="config">The configuration.</param>
         /// <param name="appSettingsFolderPath">The application settings folder path.</param>
         /// <param name="appSettingsFileName">Name of the application settings file.</param>
-        public static void LoadAppSettings(ref RollbarConfig config, string appSettingsFolderPath, string appSettingsFileName)
+        /// <returns>false when the configuration was not found, otherwise true.</returns>
+        public static bool LoadAppSettings(ref RollbarConfig config, string appSettingsFolderPath, string appSettingsFileName)
         {
             IConfiguration appSettingsConfig = AppSettingsUtil.LoadAppSettings(appSettingsFolderPath, appSettingsFileName);
+            if (appSettingsConfig == null)
+            {
+                return false;
+            }
+
             AppSettingsUtil.LoadAppSettings(ref config, appSettingsConfig);
+            return true;
         }
 
         /// <summary>
@@ -53,11 +75,12 @@ namespace Rollbar.NetCore
         /// </summary>
         /// <param name="config">The configuration.</param>
         /// <param name="appSettings">The application settings.</param>
-        public static void LoadAppSettings(ref RollbarConfig config, IConfiguration appSettings)
+        /// <returns>false when the configuration was not found, otherwise true.</returns>
+        public static bool LoadAppSettings(ref RollbarConfig config, IConfiguration appSettings)
         {
             const string rollbarAppConfigSectionName = "Rollbar";
 
-            AppSettingsUtil.LoadAppSettings(ref config, rollbarAppConfigSectionName, appSettings);
+            return AppSettingsUtil.LoadAppSettings(ref config, rollbarAppConfigSectionName, appSettings);
         }
 
         #endregion RollbarConfig
@@ -68,10 +91,17 @@ namespace Rollbar.NetCore
         /// Loads the application settings.
         /// </summary>
         /// <param name="config">The configuration.</param>
-        public static void LoadAppSettings(ref TelemetryConfig config)
+        /// <returns>false when the configuration was not found, otherwise true.</returns>
+        public static bool LoadAppSettings(ref TelemetryConfig config)
         {
             IConfiguration appSettingsConfig = AppSettingsUtil.LoadAppSettings();
+            if (appSettingsConfig == null)
+            {
+                return false;
+            }
+
             AppSettingsUtil.LoadAppSettings(ref config, appSettingsConfig);
+            return true;
         }
 
         /// <summary>
@@ -79,10 +109,17 @@ namespace Rollbar.NetCore
         /// </summary>
         /// <param name="config">The configuration.</param>
         /// <param name="appSettingsFileName">Name of the application settings file.</param>
-        public static void LoadAppSettings(ref TelemetryConfig config, string appSettingsFileName)
+        /// <returns>false when the configuration was not found, otherwise true.</returns>
+        public static bool LoadAppSettings(ref TelemetryConfig config, string appSettingsFileName)
         {
             IConfiguration appSettingsConfig = AppSettingsUtil.LoadAppSettings(appSettingsFileName);
+            if (appSettingsConfig == null)
+            {
+                return false;
+            }
+
             AppSettingsUtil.LoadAppSettings(ref config, appSettingsConfig);
+            return true;
         }
 
         /// <summary>
@@ -91,10 +128,17 @@ namespace Rollbar.NetCore
         /// <param name="config">The configuration.</param>
         /// <param name="appSettingsFolderPath">The application settings folder path.</param>
         /// <param name="appSettingsFileName">Name of the application settings file.</param>
-        public static void LoadAppSettings(ref TelemetryConfig config, string appSettingsFolderPath, string appSettingsFileName)
+        /// <returns>false when the configuration was not found, otherwise true.</returns>
+        public static bool LoadAppSettings(ref TelemetryConfig config, string appSettingsFolderPath, string appSettingsFileName)
         {
             IConfiguration appSettingsConfig = AppSettingsUtil.LoadAppSettings(appSettingsFolderPath, appSettingsFileName);
+            if (appSettingsConfig == null)
+            {
+                return false;
+            }
+
             AppSettingsUtil.LoadAppSettings(ref config, appSettingsConfig);
+            return true;
         }
 
         /// <summary>
@@ -102,16 +146,15 @@ namespace Rollbar.NetCore
         /// </summary>
         /// <param name="config">The configuration.</param>
         /// <param name="appSettings">The application settings.</param>
-        public static void LoadAppSettings(ref TelemetryConfig config, IConfiguration appSettings)
+        /// <returns>false when the configuration was not found, otherwise true.</returns>
+        public static bool LoadAppSettings(ref TelemetryConfig config, IConfiguration appSettings)
         {
             const string rollbarAppConfigSectionName = "RollbarTelemetry";
 
-            AppSettingsUtil.LoadAppSettings(ref config, rollbarAppConfigSectionName, appSettings);
+            return AppSettingsUtil.LoadAppSettings(ref config, rollbarAppConfigSectionName, appSettings);
         }
 
         #endregion TelemetryConfig
-
-
 
         private static IConfiguration LoadAppSettings()
         {
@@ -128,14 +171,18 @@ namespace Rollbar.NetCore
 
         private static IConfiguration LoadAppSettings(string folderPath, string appSettingsFileName)
         {
-            Assumption.AssertTrue(
-                Directory.Exists(folderPath), 
-                nameof(folderPath)
-                );
-            Assumption.AssertTrue(
-                File.Exists(Path.Combine(folderPath, appSettingsFileName)), 
-                nameof(appSettingsFileName)
-                );
+            if (!Directory.Exists(folderPath))
+            {
+                Debug.WriteLine($"Folder: {folderPath} does not exist...");
+                return null;
+            }
+
+            string fileFullName = Path.Combine(folderPath, appSettingsFileName);
+            if (!File.Exists(fileFullName))
+            {
+                Debug.WriteLine($"File: {fileFullName} does not exist...");
+                return null;
+            }
 
             IConfiguration appConfiguration = new ConfigurationBuilder()
                 .SetBasePath(folderPath)
@@ -150,9 +197,24 @@ namespace Rollbar.NetCore
             return appSettings.GetSection(sectionName).Get<TSection>();
         }
 
-        private static void LoadAppSettings<TSection>(ref TSection section, string sectionName, IConfiguration appSettings)
+        /// <summary>
+        /// Loads the application settings.
+        /// </summary>
+        /// <typeparam name="TSection">The type of the t section.</typeparam>
+        /// <param name="section">The section.</param>
+        /// <param name="sectionName">Name of the section.</param>
+        /// <param name="appSettings">The application settings.</param>
+        /// <returns>false when the specified section was not found, otherwise true.</returns>
+        private static bool LoadAppSettings<TSection>(ref TSection section, string sectionName, IConfiguration appSettings)
         {
-            appSettings.GetSection(sectionName).Bind(section);
+            IConfigurationSection configurationSection = appSettings.GetSection(sectionName);
+            if (configurationSection == null)
+            {
+                return false;
+            }
+
+            configurationSection.Bind(section);
+            return true;
         }
     }
 }

--- a/Rollbar/NetFramework/AppConfigUtil.cs
+++ b/Rollbar/NetFramework/AppConfigUtil.cs
@@ -1,0 +1,162 @@
+﻿namespace Rollbar.NetFramework
+{
+    using Rollbar.Telemetry;
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    /// <summary>
+    /// Class AppConfigUtil.
+    /// It aids in configuration of Rollbar configuration objects based on content of an app.config file (if any). 
+    /// </summary>
+    public static class AppConfigUtil
+    {
+        private static readonly string[] listValueSplitters = new string[] { ", ", "; ", " " };
+
+        #region RollbarConfig
+
+        /// <summary>
+        /// Loads the application settings.
+        /// </summary>
+        /// <param name="rollbarConfig">The Rollbar configuration.</param>
+        /// <returns>false when the configuration was not found, otherwise true.</returns>
+        public static bool LoadAppSettings(ref RollbarConfig rollbarConfig)
+        {
+            return AppConfigUtil.LoadAppSettings(ref rollbarConfig, RollbarConfigSection.GetConfiguration());
+        }
+
+        /// <summary>
+        /// Loads the application settings.
+        /// </summary>
+        /// <param name="rollbarConfig">The configuration.</param>
+        /// <param name="rollbarConfigSection">The application settings.</param>
+        /// <returns>false when the configuration was not found, otherwise true.</returns>
+        public static bool LoadAppSettings(ref RollbarConfig rollbarConfig, RollbarConfigSection rollbarConfigSection)
+        {
+            if (rollbarConfigSection == null)
+            {
+                return false;
+            }
+
+            if (!string.IsNullOrWhiteSpace(rollbarConfigSection.AccessToken))
+            {
+                rollbarConfig.AccessToken = rollbarConfigSection.AccessToken;
+            }
+            if (!string.IsNullOrWhiteSpace(rollbarConfigSection.Environment))
+            {
+                rollbarConfig.Environment = rollbarConfigSection.Environment;
+            }
+            if (rollbarConfigSection.Enabled.HasValue)
+            {
+                rollbarConfig.Enabled = rollbarConfigSection.Enabled.Value;
+            }
+            if (rollbarConfigSection.MaxReportsPerMinute.HasValue)
+            {
+                rollbarConfig.MaxReportsPerMinute = rollbarConfigSection.MaxReportsPerMinute.Value;
+            }
+            if (rollbarConfigSection.ReportingQueueDepth.HasValue)
+            {
+                rollbarConfig.ReportingQueueDepth = rollbarConfigSection.ReportingQueueDepth.Value;
+            }
+            if (rollbarConfigSection.MaxItems.HasValue)
+            {
+                rollbarConfig.MaxItems = rollbarConfigSection.MaxItems.Value;
+            }
+            if (rollbarConfigSection.CaptureUncaughtExceptions.HasValue)
+            {
+                rollbarConfig.CaptureUncaughtExceptions = rollbarConfigSection.CaptureUncaughtExceptions.Value;
+            }
+            if (rollbarConfigSection.LogLevel.HasValue)
+            {
+                rollbarConfig.LogLevel = rollbarConfigSection.LogLevel.Value;
+            }
+            if (rollbarConfigSection.ScrubFields != null && rollbarConfigSection.ScrubFields.Length > 0)
+            {
+                rollbarConfig.ScrubFields =
+                    string.IsNullOrEmpty(rollbarConfigSection.ScrubFields) ? new string[0]
+                    : rollbarConfigSection.ScrubFields.Split(listValueSplitters, StringSplitOptions.RemoveEmptyEntries);
+            }
+            if (rollbarConfigSection.ScrubWhitelistFields != null && rollbarConfigSection.ScrubWhitelistFields.Length > 0)
+            {
+                rollbarConfig.ScrubWhitelistFields =
+                    string.IsNullOrEmpty(rollbarConfigSection.ScrubWhitelistFields) ? new string[0]
+                    : rollbarConfigSection.ScrubWhitelistFields.Split(listValueSplitters, StringSplitOptions.RemoveEmptyEntries);
+            }
+            if (!string.IsNullOrWhiteSpace(rollbarConfigSection.EndPoint))
+            {
+                rollbarConfig.EndPoint = rollbarConfigSection.EndPoint;
+            }
+            if (!string.IsNullOrWhiteSpace(rollbarConfigSection.ProxyAddress))
+            {
+                rollbarConfig.ProxyAddress = rollbarConfigSection.ProxyAddress;
+            }
+            if (!string.IsNullOrWhiteSpace(rollbarConfigSection.ProxyUsername))
+            {
+                rollbarConfig.ProxyUsername = rollbarConfigSection.ProxyUsername;
+            }
+            if (!string.IsNullOrWhiteSpace(rollbarConfigSection.ProxyPassword))
+            {
+                rollbarConfig.ProxyPassword = rollbarConfigSection.ProxyPassword;
+            }
+            if (rollbarConfigSection.PersonDataCollectionPolicies.HasValue)
+            {
+                rollbarConfig.PersonDataCollectionPolicies = rollbarConfigSection.PersonDataCollectionPolicies.Value;
+            }
+            if (rollbarConfigSection.IpAddressCollectionPolicy.HasValue)
+            {
+                rollbarConfig.IpAddressCollectionPolicy = rollbarConfigSection.IpAddressCollectionPolicy.Value;
+            }
+
+            return true;
+        }
+
+        #endregion RollbarConfig
+
+        #region TelemetryConfig
+
+        /// <summary>
+        /// Loads the application settings.
+        /// </summary>
+        /// <param name="telemetryConfig">The configuration.</param>
+        /// <returns>false when the configuration was not found, otherwise true.</returns>
+        public static bool LoadAppSettings(ref TelemetryConfig telemetryConfig)
+        {
+            return AppConfigUtil.LoadAppSettings(ref telemetryConfig, RollbarTelemetryConfigSection.GetConfiguration());
+        }
+
+        /// <summary>
+        /// Loads the application settings.
+        /// </summary>
+        /// <param name="telemetryConfig">The configuration.</param>
+        /// <param name="telemetryConfigSection">The application settings.</param>
+        /// <returns>false when the configuration was not found, otherwise true.</returns>
+        public static bool LoadAppSettings(ref TelemetryConfig telemetryConfig, RollbarTelemetryConfigSection telemetryConfigSection)
+        {
+            if (telemetryConfigSection == null)
+            {
+                return false;
+            }
+
+            if (telemetryConfigSection.TelemetryEnabled.HasValue)
+            {
+                telemetryConfig.TelemetryEnabled = telemetryConfigSection.TelemetryEnabled.Value;
+            }
+            if (telemetryConfigSection.TelemetryQueueDepth.HasValue)
+            {
+                telemetryConfig.TelemetryQueueDepth = telemetryConfigSection.TelemetryQueueDepth.Value;
+            }
+            if (telemetryConfigSection.TelemetryAutoCollectionTypes.HasValue)
+            {
+                telemetryConfig.TelemetryAutoCollectionTypes = telemetryConfigSection.TelemetryAutoCollectionTypes.Value;
+            }
+            if (telemetryConfigSection.TelemetryAutoCollectionInterval.HasValue)
+            {
+                telemetryConfig.TelemetryAutoCollectionInterval = telemetryConfigSection.TelemetryAutoCollectionInterval.Value;
+            }
+
+            return true;
+        }
+    }
+
+    #endregion TelemetryConfig
+}

--- a/Rollbar/NetFramework/AppConfigUtil.cs
+++ b/Rollbar/NetFramework/AppConfigUtil.cs
@@ -2,8 +2,6 @@
 {
     using Rollbar.Telemetry;
     using System;
-    using System.Collections.Generic;
-    using System.Text;
 
     /// <summary>
     /// Class AppConfigUtil.

--- a/Rollbar/NetFramework/RollbarConfigSection.cs
+++ b/Rollbar/NetFramework/RollbarConfigSection.cs
@@ -1,6 +1,5 @@
 ﻿namespace Rollbar.NetFramework
 {
-#if NETFX || NETSTANDARD
     using System;
     using System.Configuration;
 
@@ -23,12 +22,9 @@
         public static RollbarConfigSection GetConfiguration()
         {
             RollbarConfigSection configuration =
-                ConfigurationManager.GetSection("rollbar") as RollbarConfigSection;
-
-            if (configuration != null)
-                return configuration;
-
-            return new RollbarConfigSection();
+                ConfigurationManager.GetSection("rollbar") 
+                as RollbarConfigSection;
+            return null;
         }
 
         /// <summary>
@@ -255,6 +251,5 @@
             }
         }
     }
-#endif
 
 }

--- a/Rollbar/NetFramework/RollbarTelemetryConfigSection.cs
+++ b/Rollbar/NetFramework/RollbarTelemetryConfigSection.cs
@@ -1,7 +1,5 @@
 ﻿namespace Rollbar.NetFramework
 {
-
-#if NETFX || NETSTANDARD
     using System;
     using System.Configuration;
     using Rollbar.DTOs;
@@ -25,12 +23,9 @@
         public static RollbarTelemetryConfigSection GetConfiguration()
         {
             RollbarTelemetryConfigSection configuration =
-                ConfigurationManager.GetSection("rollbarTelemetry") as RollbarTelemetryConfigSection;
-
-            if (configuration != null)
-                return configuration;
-
-            return new RollbarTelemetryConfigSection();
+                ConfigurationManager.GetSection("rollbarTelemetry") 
+                as RollbarTelemetryConfigSection;
+            return configuration;
         }
 
         /// <summary>
@@ -91,6 +86,5 @@
         }
 
     }
-#endif
 
 }

--- a/Rollbar/NetStandard/RollbarConfigUtil.cs
+++ b/Rollbar/NetStandard/RollbarConfigUtil.cs
@@ -3,19 +3,144 @@
     using System;
     using System.Collections.Generic;
     using System.Text;
+    using Rollbar.Telemetry;
 
+    /// <summary>
+    /// Class RollbarConfigUtil.
+    /// </summary>
     public static class RollbarConfigUtil
     {
-        public static IRollbarConfig LoadConfig()
+        /// <summary>
+        /// Loads the specified configuration.
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        /// <returns><c>true</c> if configuration was found, <c>false</c> otherwise.</returns>
+        public static bool Load(RollbarConfig config)
         {
+            // try app.config file:
+            if (NetFramework.AppConfigUtil.LoadAppSettings(ref config))
+            {
+                return true;
+            }
+
+#if NETCOREAPP || NETSTANDARD
+            // try appsettings.json file:
+            if (NetCore.AppSettingsUtil.LoadAppSettings(ref config))
+            {
+                return true;
+            }
+#endif
+
+            return false;
+        }
+
+        /// <summary>
+        /// Loads the specified configuration.
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        /// <returns><c>true</c> if configuration was found, <c>false</c> otherwise.</returns>
+        public static bool Load(TelemetryConfig config)
+        {
+            // try app.config file:
+            if (NetFramework.AppConfigUtil.LoadAppSettings(ref config))
+            {
+                return true;
+            }
+
+#if NETCOREAPP || NETSTANDARD
+            // try appsettings.json file:
+            if (NetCore.AppSettingsUtil.LoadAppSettings(ref config))
+            {
+                return true;
+            }
+#endif
+
+            return false;
+        }
+
+        /// <summary>
+        /// Loads the rollbar configuration.
+        /// </summary>
+        /// <returns>Either IRollbarConfig or null if no configuration file found.</returns>
+        public static IRollbarConfig LoadRollbarConfig()
+        {
+            RollbarConfig config = new RollbarConfig("seedToken");
+            if(RollbarConfigUtil.Load(config))
+            {
+                return config;
+            }
             return null;
         }
 
-        public static IRollbarConfig LoadConfig(string configFilePath)
+        /// <summary>
+        /// Loads the telemetry configuration.
+        /// </summary>
+        /// <returns>ITelemetryConfig.</returns>
+        /// <returns>Either IRollbarConfig or null if no configuration file found.</returns>
+        public static ITelemetryConfig LoadTelemetryConfig()
         {
+            TelemetryConfig config = new TelemetryConfig();
+            if (RollbarConfigUtil.Load(config))
+            {
+                return config;
+            }
             return null;
         }
 
+
+#if NETCOREAPP || NETSTANDARD
+
+        /// <summary>
+        /// Loads the rollbar configuration.
+        /// </summary>
+        /// <param name="configFileName">Name of the configuration file.</param>
+        /// <param name="configFilePath">The configuration file path.</param>
+        /// <returns>Either IRollbarConfig or null if no configuration file found.</returns>
+        public static IRollbarConfig LoadRollbarConfig(string configFileName, string configFilePath = null)
+        {
+            RollbarConfig config = new RollbarConfig("seedToken");
+
+            if (string.IsNullOrWhiteSpace(configFilePath))
+            {
+                if (!NetCore.AppSettingsUtil.LoadAppSettings(ref config, configFileName))
+                {
+                    return null;
+                }
+            }
+            else if (!NetCore.AppSettingsUtil.LoadAppSettings(ref config, configFilePath, configFileName))
+            {
+                return null;
+            }
+
+            return config;
+        }
+
+        /// <summary>
+        /// Loads the telemetry configuration.
+        /// </summary>
+        /// <param name="configFileName">Name of the configuration file.</param>
+        /// <param name="configFilePath">The configuration file path.</param>
+        /// <returns>Either IRollbarConfig or null if no configuration file found.</returns>
+        public static ITelemetryConfig LoadTelemetryConfig(string configFileName, string configFilePath = null)
+        {
+            TelemetryConfig config = new TelemetryConfig();
+
+            if (string.IsNullOrWhiteSpace(configFilePath))
+            {
+                if (!NetCore.AppSettingsUtil.LoadAppSettings(ref config, configFileName))
+                {
+                    return null;
+                }
+            }
+            else if (!NetCore.AppSettingsUtil.LoadAppSettings(ref config, configFilePath, configFileName))
+            {
+                return null;
+            }
+
+            return config;
+        }
+
+#endif
 
     }
 }

--- a/Rollbar/NetStandard/RollbarConfigUtil.cs
+++ b/Rollbar/NetStandard/RollbarConfigUtil.cs
@@ -1,8 +1,6 @@
 ﻿namespace Rollbar.NetStandard
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
     using Rollbar.Telemetry;
 
     /// <summary>

--- a/Rollbar/PayloadQueue.cs
+++ b/Rollbar/PayloadQueue.cs
@@ -12,7 +12,7 @@ namespace Rollbar
         private readonly object _syncLock = null;
         private readonly Queue<Payload> _queue = null;
         private readonly RollbarLogger _logger = null;
-        private readonly RollbarClient _client = null;
+        private RollbarClient _client = null;
         private bool _isReleased;
 
         private PayloadQueue()
@@ -44,6 +44,19 @@ namespace Rollbar
         public RollbarLogger Logger
         {
             get { return this._logger; }
+        }
+
+        public void UpdateClient(RollbarClient client)
+        {
+            if (this._client == client)
+            {
+                return;
+            }
+
+            lock(this._syncLock)
+            {
+                this._client = client;
+            }
         }
 
         public RollbarClient Client

--- a/Rollbar/PlugIns/PlugInCore.cs
+++ b/Rollbar/PlugIns/PlugInCore.cs
@@ -1,0 +1,170 @@
+﻿namespace Rollbar.PlugIns
+{
+    using Rollbar.Diagnostics;
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    public abstract class PlugInCore<TPlugInErrorLevel, TPlugInEventData>
+    {
+        private static readonly TimeSpan defaultRollbarBlockingTimeout = TimeSpan.FromSeconds(3);
+
+        private readonly string _customPrefix;
+        private readonly IDictionary<TPlugInErrorLevel, ErrorLevel> _rollbarErrorLevelByPlugInErrorLevel;
+
+        /// <summary>
+        /// The Rollbar configuration
+        /// </summary>
+        private readonly IRollbarConfig _rollbarConfig;
+        /// <summary>
+        /// The Rollbar asynchronous logger
+        /// </summary>
+        private readonly IAsyncLogger _rollbarAsyncLogger;
+        /// <summary>
+        /// The Rollbar logger
+        /// </summary>
+        private readonly ILogger _rollbarLogger;
+
+        private PlugInCore()
+        {
+
+        }
+
+        public PlugInCore(
+            IDictionary<TPlugInErrorLevel, ErrorLevel> rollbarErrorLevelByPlugInErrorLevel,
+            string customPrefix,
+            IRollbarConfig rollbarConfig,
+            TimeSpan? rollbarBlockingTimeout
+            )
+        {
+            this._rollbarErrorLevelByPlugInErrorLevel = rollbarErrorLevelByPlugInErrorLevel;
+            this._customPrefix = customPrefix.EndsWith(".") ? customPrefix : customPrefix + ".";
+            this._rollbarConfig = rollbarConfig;
+
+            RollbarFactory.CreateProper(
+                this._rollbarConfig,
+                rollbarBlockingTimeout,
+                out this._rollbarAsyncLogger,
+                out this._rollbarLogger
+                );
+        }
+
+        public virtual void ReportToRollbar(TPlugInEventData plugInEventData, TPlugInErrorLevel plugInErrorLevel)
+        {
+            if (plugInEventData == null)
+            {
+                return;
+            }
+
+            DTOs.Data data = null;// this.Translate(plugInEventData, plugInErrorLevel);
+
+            try
+            {
+                data = this.Translate(plugInEventData, plugInErrorLevel);
+            }
+            catch(Exception ex)
+            {
+                data = new DTOs.Data(this._rollbarConfig, new DTOs.Body(ex));
+            }
+            finally
+            {
+                if (data != null)
+                {
+                    this.ReportToRollbar(data);
+                }
+            }
+        }
+
+        protected virtual DTOs.Data Translate(TPlugInEventData plugInEventData, TPlugInErrorLevel plugInErrorLevel)
+        {
+            ErrorLevel errorLevel = this.Translate(plugInErrorLevel);
+            string message = this.ExtractMessage(plugInEventData);
+            Exception exception = this.ExtractException(plugInEventData);
+            IDictionary<string, object> pluginEventProperties = this.ExtractCustomProperties(plugInEventData);
+
+            DTOs.Body rollbarBody = null;
+            if (exception != null)
+            {
+                rollbarBody = new DTOs.Body(exception);
+            }
+            else
+            {
+                rollbarBody = new DTOs.Body(new DTOs.Message(message));
+            }
+
+            IDictionary<string, object> custom = new Dictionary<string, object>(pluginEventProperties.Count);
+            foreach(var property in pluginEventProperties)
+            {
+                custom[this._customPrefix + property.Key] = property.Value;
+            }
+
+            DTOs.Data rollbarData = new DTOs.Data(this._rollbarConfig, rollbarBody, custom)
+            {
+                Level = errorLevel
+            };
+
+            return rollbarData;
+        }
+
+        /// <summary>
+        /// Translates the specified plug-in error level to Rollbar ErrorLevel.
+        /// </summary>
+        /// <param name="plugInErrorLevel">The plug-in error level.</param>
+        /// <returns>ErrorLevel.</returns>
+        protected virtual ErrorLevel Translate(TPlugInErrorLevel plugInErrorLevel)
+        {
+            if (plugInErrorLevel == null)
+            {
+                return ErrorLevel.Debug;
+            }
+
+            if (this._rollbarErrorLevelByPlugInErrorLevel.TryGetValue(plugInErrorLevel, out ErrorLevel rollbarErrorLevel))
+            {
+                return rollbarErrorLevel;
+            }
+
+            return ErrorLevel.Debug;
+        }
+
+        protected abstract string ExtractMessage(TPlugInEventData plugInEventData);
+        protected abstract Exception ExtractException(TPlugInEventData plugInEventData);
+        protected abstract IDictionary<string, object> ExtractCustomProperties(TPlugInEventData plugInEventData);
+
+        /// <summary>
+        /// Reports data to Rollbar.
+        /// </summary>
+        /// <param name="rollbarData">The Rollbar data.</param>
+        private void ReportToRollbar(DTOs.Data rollbarData)
+        {
+            if (this._rollbarAsyncLogger != null)
+            {
+                ReportToRollbar(this._rollbarAsyncLogger, rollbarData);
+            }
+            else if (this._rollbarLogger != null)
+            {
+                ReportToRollbar(this._rollbarLogger, rollbarData);
+            }
+        }
+
+        /// <summary>
+        /// Reports data to Rollbar.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="rollbarData">The Rollbar data.</param>
+        private static void ReportToRollbar(ILogger logger, DTOs.Data rollbarData)
+        {
+            logger.Log(rollbarData);
+        }
+
+        /// <summary>
+        /// Reports data to Rollbar.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="rollbarData">The Rollbar data.</param>
+        private static void ReportToRollbar(IAsyncLogger logger, DTOs.Data rollbarData)
+        {
+            logger.Log(rollbarData);
+        }
+
+    }
+}

--- a/Rollbar/PlugIns/PlugInCore.cs
+++ b/Rollbar/PlugIns/PlugInCore.cs
@@ -1,10 +1,15 @@
 ﻿namespace Rollbar.PlugIns
 {
-    using Rollbar.Diagnostics;
     using System;
     using System.Collections.Generic;
-    using System.Text;
 
+    /// <summary>
+    /// Class PlugInCore.
+    /// Implements the <see cref="System.IDisposable" />
+    /// </summary>
+    /// <typeparam name="TPlugInErrorLevel">The type of the t plug in error level.</typeparam>
+    /// <typeparam name="TPlugInEventData">The type of the t plug in event data.</typeparam>
+    /// <seealso cref="System.IDisposable" />
     public abstract class PlugInCore<TPlugInErrorLevel, TPlugInEventData>
         : IDisposable
     {
@@ -37,6 +42,9 @@
         /// </summary>
         private readonly ILogger _rollbarLogger;
 
+        /// <summary>
+        /// Prevents a default instance of the <see cref="PlugInCore{TPlugInErrorLevel, TPlugInEventData}"/> class from being created.
+        /// </summary>
         private PlugInCore()
         {
         }
@@ -70,11 +78,8 @@
 
             if (this._rollbarConfig == null)
             {
-                IRollbarConfig config = NetStandard.RollbarConfigUtil.LoadRollbarConfig(); //new RollbarConfig("just_a_seed_value");
+                IRollbarConfig config = NetStandard.RollbarConfigUtil.LoadRollbarConfig();
                                                                                          
-//#if NETSTANDARD
-//                Rollbar.NetCore.AppSettingsUtil.LoadAppSettings(ref config);
-//#endif
                 this._rollbarConfig = config;
             }
 

--- a/Rollbar/PlugIns/PlugInCore.cs
+++ b/Rollbar/PlugIns/PlugInCore.cs
@@ -70,10 +70,11 @@
 
             if (this._rollbarConfig == null)
             {
-                RollbarConfig config = new RollbarConfig("just_a_seed_value");
-#if NETSTANDARD
-                Rollbar.NetCore.AppSettingsUtil.LoadAppSettings(ref config);
-#endif
+                IRollbarConfig config = NetStandard.RollbarConfigUtil.LoadRollbarConfig(); //new RollbarConfig("just_a_seed_value");
+                                                                                         
+//#if NETSTANDARD
+//                Rollbar.NetCore.AppSettingsUtil.LoadAppSettings(ref config);
+//#endif
                 this._rollbarConfig = config;
             }
 

--- a/Rollbar/PlugIns/PlugInCore.cs
+++ b/Rollbar/PlugIns/PlugInCore.cs
@@ -6,10 +6,22 @@
     using System.Text;
 
     public abstract class PlugInCore<TPlugInErrorLevel, TPlugInEventData>
+        : IDisposable
     {
-        private static readonly TimeSpan defaultRollbarBlockingTimeout = TimeSpan.FromSeconds(3);
+        /// <summary>
+        /// The default RollbarLogger's blocking timeout.
+        /// </summary>
+        public static readonly TimeSpan DefaultRollbarBlockingTimeout = TimeSpan.FromSeconds(3);
 
+        /// <summary>
+        /// The custom prefix for the Rollbar payload custom fields.
+        /// </summary>
         private readonly string _customPrefix;
+
+        /// <summary>
+        /// The Rollbar ErrorLevel by plug-in's error level.
+        /// Essentially, a one-directional map from plug-in's error level value to Rollbar ErrorLevel.
+        /// </summary>
         private readonly IDictionary<TPlugInErrorLevel, ErrorLevel> _rollbarErrorLevelByPlugInErrorLevel;
 
         /// <summary>
@@ -27,10 +39,25 @@
 
         private PlugInCore()
         {
-
         }
 
-        public PlugInCore(
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlugInCore{TPlugInErrorLevel, TPlugInEventData}"/> class.
+        /// </summary>
+        /// <param name="rollbarErrorLevelByPlugInErrorLevel">
+        /// The Rollbar ErrorLevel by plug-in's error level. 
+        /// Essentially, a one-directional map from plug-in's error level value to Rollbar ErrorLevel.
+        /// </param>
+        /// <param name="customPrefix">
+        /// The custom prefix for the Rollbar payload custom fields.
+        /// </param>
+        /// <param name="rollbarConfig">
+        /// The Rollbar configuration.
+        /// </param>
+        /// <param name="rollbarBlockingTimeout">
+        /// The RollbarLogger's blocking timeout.
+        /// </param>
+        protected PlugInCore(
             IDictionary<TPlugInErrorLevel, ErrorLevel> rollbarErrorLevelByPlugInErrorLevel,
             string customPrefix,
             IRollbarConfig rollbarConfig,
@@ -38,8 +65,17 @@
             )
         {
             this._rollbarErrorLevelByPlugInErrorLevel = rollbarErrorLevelByPlugInErrorLevel;
-            this._customPrefix = customPrefix.EndsWith(".") ? customPrefix : customPrefix + ".";
+            this._customPrefix = customPrefix;//= customPrefix.EndsWith(".") ? customPrefix : customPrefix + ".";
             this._rollbarConfig = rollbarConfig;
+
+            if (this._rollbarConfig == null)
+            {
+                RollbarConfig config = new RollbarConfig("just_a_seed_value");
+#if NETSTANDARD
+                Rollbar.NetCore.AppSettingsUtil.LoadAppSettings(ref config);
+#endif
+                this._rollbarConfig = config;
+            }
 
             RollbarFactory.CreateProper(
                 this._rollbarConfig,
@@ -49,6 +85,11 @@
                 );
         }
 
+        /// <summary>
+        /// Reports to rollbar.
+        /// </summary>
+        /// <param name="plugInEventData">The plug in event data.</param>
+        /// <param name="plugInErrorLevel">The plug in error level.</param>
         public virtual void ReportToRollbar(TPlugInEventData plugInEventData, TPlugInErrorLevel plugInErrorLevel)
         {
             if (plugInEventData == null)
@@ -75,12 +116,29 @@
             }
         }
 
+        /// <summary>
+        /// Creates the configuration.
+        /// </summary>
+        /// <param name="rollbarAccessToken">The Rollbar access token.</param>
+        /// <param name="rollbarEnvironment">The Rollbar environment.</param>
+        /// <returns>IRollbarConfig.</returns>
+        public static IRollbarConfig CreateConfig(string rollbarAccessToken, string rollbarEnvironment)
+        {
+            return new RollbarConfig(rollbarAccessToken) { Environment = rollbarEnvironment, };
+        }
+
+        /// <summary>
+        /// Translates the specified plug in event data into a Rollbar.DTOs.Data instance.
+        /// </summary>
+        /// <param name="plugInEventData">The plug in event data.</param>
+        /// <param name="plugInErrorLevel">The plug in error level.</param>
+        /// <returns>Rollbar.DTOs.Data instance.</returns>
         protected virtual DTOs.Data Translate(TPlugInEventData plugInEventData, TPlugInErrorLevel plugInErrorLevel)
         {
             ErrorLevel errorLevel = this.Translate(plugInErrorLevel);
             string message = this.ExtractMessage(plugInEventData);
             Exception exception = this.ExtractException(plugInEventData);
-            IDictionary<string, object> pluginEventProperties = this.ExtractCustomProperties(plugInEventData);
+            object pluginEventProperties = this.ExtractCustomProperties(plugInEventData);
 
             DTOs.Body rollbarBody = null;
             if (exception != null)
@@ -92,10 +150,12 @@
                 rollbarBody = new DTOs.Body(new DTOs.Message(message));
             }
 
-            IDictionary<string, object> custom = new Dictionary<string, object>(pluginEventProperties.Count);
-            foreach(var property in pluginEventProperties)
+            IDictionary<string, object> custom = null;
+            if (pluginEventProperties != null)
             {
-                custom[this._customPrefix + property.Key] = property.Value;
+                const int customCapacity = 1;
+                custom = new Dictionary<string, object>(customCapacity);
+                custom[this._customPrefix] = pluginEventProperties;
             }
 
             DTOs.Data rollbarData = new DTOs.Data(this._rollbarConfig, rollbarBody, custom)
@@ -126,9 +186,26 @@
             return ErrorLevel.Debug;
         }
 
+        /// <summary>
+        /// Extracts the message for a Rollbar payload from the incoming plug-in's data event.
+        /// </summary>
+        /// <param name="plugInEventData">The plug in event data.</param>
+        /// <returns>System.String.</returns>
         protected abstract string ExtractMessage(TPlugInEventData plugInEventData);
+
+        /// <summary>
+        /// Extracts the exception for a Rollbar payload from the incoming plug-in's data event.
+        /// </summary>
+        /// <param name="plugInEventData">The plug in event data.</param>
+        /// <returns>Exception.</returns>
         protected abstract Exception ExtractException(TPlugInEventData plugInEventData);
-        protected abstract IDictionary<string, object> ExtractCustomProperties(TPlugInEventData plugInEventData);
+
+        /// <summary>
+        /// Extracts the custom properties  for a Rollbar payload from the incoming plug-in's data event.
+        /// </summary>
+        /// <param name="plugInEventData">The plug in event data.</param>
+        /// <returns>Usually, either a data structure or a key-value dictionary returned as a System.Object.</returns>
+        protected abstract object ExtractCustomProperties(TPlugInEventData plugInEventData);
 
         /// <summary>
         /// Reports data to Rollbar.
@@ -165,6 +242,54 @@
         {
             logger.Log(rollbarData);
         }
+
+        #region IDisposable Support
+
+        private bool disposedValue = false; // To detect redundant calls
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        /// <param name="disposing">
+        /// <c>true</c> to release both managed and unmanaged resources; 
+        /// <c>false</c> to release only unmanaged resources.
+        /// </param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    // TODO: dispose managed state (managed objects).
+                    (this._rollbarAsyncLogger as IDisposable)?.Dispose();
+                    (this._rollbarLogger as IDisposable)?.Dispose();
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
+                // TODO: set large fields to null.
+
+                disposedValue = true;
+            }
+        }
+
+        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
+        // ~PlugInCore() {
+        //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+        //   Dispose(false);
+        // }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+            // TODO: uncomment the following line if the finalizer is overridden above.
+            // GC.SuppressFinalize(this);
+        }
+
+        #endregion
 
     }
 }

--- a/Rollbar/RollbarConfig.cs
+++ b/Rollbar/RollbarConfig.cs
@@ -106,7 +106,18 @@
         {
             base.Reconfigure(likeMe);
 
-            this.Logger.Queue.NextDequeueTime = DateTimeOffset.Now;
+            var rollbarClient = new RollbarClient(
+                this
+                , RollbarQueueController.Instance.ProvideHttpClient(this.ProxyAddress, this.ProxyUsername, this.ProxyPassword)
+                );
+
+            if (this.Logger != null && this.Logger.Queue != null)
+            {
+                // reset the queue to use the new RollbarClient:
+                this.Logger.Queue.Flush();
+                this.Logger.Queue.UpdateClient(rollbarClient);
+                this.Logger.Queue.NextDequeueTime = DateTimeOffset.Now;
+            }
 
             return this;
         }

--- a/Rollbar/RollbarConfig.cs
+++ b/Rollbar/RollbarConfig.cs
@@ -5,6 +5,7 @@
     using Rollbar.Common;
     using Rollbar.Diagnostics;
     using Rollbar.DTOs;
+    using Rollbar.NetFramework;
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
@@ -26,8 +27,6 @@
         , ITraceable
         , IRollbarConfig
     {
-        private static readonly string[] listValueSplitters = new string[] { ", ", "; ", " " };
-
         private readonly RollbarLogger _logger = null;
 
         private RollbarConfig()
@@ -39,27 +38,6 @@
             this._logger = logger;
 
             this.SetDefaults();
-        }
-
-        internal RollbarLogger Logger
-        {
-            get { return this._logger; }
-        }
-
-        /// <summary>
-        /// Reconfigures this object similar to the specified one.
-        /// </summary>
-        /// <param name="likeMe">The pre-configured instance to be cloned in terms of its configuration/settings.</param>
-        /// <returns>
-        /// Reconfigured instance.
-        /// </returns>
-        public override RollbarConfig Reconfigure(IRollbarConfig likeMe)
-        {
-            base.Reconfigure(likeMe);
-
-            this.Logger.Queue.NextDequeueTime = DateTimeOffset.Now;
-
-            return this;
         }
 
         /// <summary>
@@ -108,92 +86,31 @@
             this.PersonDataCollectionPolicies = PersonDataCollectionPolicies.None;
             this.IpAddressCollectionPolicy = IpAddressCollectionPolicy.Collect;
 
-#if NETFX
-            // initialize based on app.config settings of Rollbar section (if any):
-            this.InitFromAppConfig();
-#endif
+            // initialize based on application configuration file (if any):
+            NetStandard.RollbarConfigUtil.Load(this);
         }
 
-#if NETFX
-        private void InitFromAppConfig()
+        internal RollbarLogger Logger
         {
-            Rollbar.NetFramework.RollbarConfigSection config = 
-                Rollbar.NetFramework.RollbarConfigSection.GetConfiguration();
-            if (config == null)
-            {
-                return;
-            }
-
-            if (!string.IsNullOrWhiteSpace(config.AccessToken))
-            {
-                this.AccessToken = config.AccessToken;
-            }
-            if (!string.IsNullOrWhiteSpace(config.Environment))
-            {
-                this.Environment = config.Environment;
-            }
-            if (config.Enabled.HasValue)
-            {
-                this.Enabled = config.Enabled.Value;
-            }
-            if (config.MaxReportsPerMinute.HasValue)
-            {
-                this.MaxReportsPerMinute = config.MaxReportsPerMinute.Value;
-            }
-            if (config.ReportingQueueDepth.HasValue)
-            {
-                this.ReportingQueueDepth = config.ReportingQueueDepth.Value;
-            }
-            if (config.MaxItems.HasValue)
-            {
-                this.MaxItems = config.MaxItems.Value;
-            }
-            if (config.CaptureUncaughtExceptions.HasValue)
-            {
-                this.CaptureUncaughtExceptions = config.CaptureUncaughtExceptions.Value;
-            }
-            if (config.LogLevel.HasValue)
-            {
-                this.LogLevel = config.LogLevel.Value;
-            }
-            if (config.ScrubFields != null && config.ScrubFields.Length > 0)
-            {
-                this.ScrubFields = 
-                    string.IsNullOrEmpty(config.ScrubFields) ? new string[0] 
-                    : config.ScrubFields.Split(listValueSplitters, StringSplitOptions.RemoveEmptyEntries);
-            }
-            if (config.ScrubWhitelistFields != null && config.ScrubWhitelistFields.Length > 0)
-            {
-                this.ScrubWhitelistFields =
-                    string.IsNullOrEmpty(config.ScrubWhitelistFields) ? new string[0]
-                    : config.ScrubWhitelistFields.Split(listValueSplitters, StringSplitOptions.RemoveEmptyEntries);
-            }
-            if (!string.IsNullOrWhiteSpace(config.EndPoint))
-            {
-                this.EndPoint = config.EndPoint;
-            }
-            if (!string.IsNullOrWhiteSpace(config.ProxyAddress))
-            {
-                this.ProxyAddress = config.ProxyAddress;
-            }
-            if (!string.IsNullOrWhiteSpace(config.ProxyUsername))
-            {
-                this.ProxyUsername = config.ProxyUsername;
-            }
-            if (!string.IsNullOrWhiteSpace(config.ProxyPassword))
-            {
-                this.ProxyPassword = config.ProxyPassword;
-            }
-            if (config.PersonDataCollectionPolicies.HasValue)
-            {
-                this.PersonDataCollectionPolicies = config.PersonDataCollectionPolicies.Value;
-            }
-            if (config.IpAddressCollectionPolicy.HasValue)
-            {
-                this.IpAddressCollectionPolicy = config.IpAddressCollectionPolicy.Value;
-            }
+            get { return this._logger; }
         }
-#endif
+
+        /// <summary>
+        /// Reconfigures this object similar to the specified one.
+        /// </summary>
+        /// <param name="likeMe">The pre-configured instance to be cloned in terms of its configuration/settings.</param>
+        /// <returns>
+        /// Reconfigured instance.
+        /// </returns>
+        public override RollbarConfig Reconfigure(IRollbarConfig likeMe)
+        {
+            base.Reconfigure(likeMe);
+
+            this.Logger.Queue.NextDequeueTime = DateTimeOffset.Now;
+
+            return this;
+        }
+
         /// <summary>
         /// Gets the access token.
         /// </summary>

--- a/Rollbar/RollbarEventArgs.cs
+++ b/Rollbar/RollbarEventArgs.cs
@@ -32,15 +32,15 @@
 
         internal RollbarEventArgs(
             RollbarLogger logger, 
-            Payload payload
+            object dataObject
             )
         {
-            Assumption.AssertNotNull(logger, nameof(logger));
+            //Assumption.AssertNotNull(logger, nameof(logger));
 
             this._logger = logger;
-            if (payload != null)
+            if (dataObject != null)
             {
-                this.Payload = JsonConvert.SerializeObject(payload);
+                this.Payload = JsonConvert.SerializeObject(dataObject);
             }
         }
 
@@ -50,7 +50,7 @@
         /// <value>
         /// The configuration.
         /// </value>
-        public IRollbarConfig Config { get { return this._logger.Config; } }
+        public IRollbarConfig Config { get { return this._logger?.Config; } }
 
         /// <summary>
         /// Gets the payload.
@@ -71,7 +71,7 @@
         {
             StringBuilder sb = new StringBuilder();
             sb.AppendLine(indent + this.GetType().Name + ":");
-            sb.Append(indent + this.Config.TraceAsString("  "));
+            sb.Append(indent + this.Config?.TraceAsString("  "));
             sb.AppendLine(indent + "  Payload: " + this.Payload);
             return sb.ToString();
         }

--- a/Rollbar/RollbarLogger.cs
+++ b/Rollbar/RollbarLogger.cs
@@ -36,9 +36,16 @@ namespace Rollbar
         private readonly PayloadQueue _payloadQueue = null;
         private readonly ConcurrentDictionary<Task, Task> _pendingTasks = new ConcurrentDictionary<Task, Task>();
 
+        /// <summary>
+        /// Occurs when a Rollbar internal event happens.
+        /// </summary>
         public event EventHandler<RollbarEventArgs> InternalEvent;
 
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RollbarLogger"/> class.
+        /// </summary>
+        /// <param name="isSingleton">if set to <c>true</c> [is singleton].</param>
+        /// <param name="rollbarConfig">The rollbar configuration.</param>
         internal RollbarLogger(bool isSingleton, IRollbarConfig rollbarConfig = null)
         {
             try
@@ -75,8 +82,16 @@ namespace Rollbar
             RollbarQueueController.Instance.Register(this._payloadQueue);
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this instance is singleton.
+        /// </summary>
+        /// <value><c>true</c> if this instance is singleton; otherwise, <c>false</c>.</value>
         internal bool IsSingleton { get; private set; }
 
+        /// <summary>
+        /// Gets the queue.
+        /// </summary>
+        /// <value>The queue.</value>
         internal PayloadQueue Queue
         {
             get { return this._payloadQueue; }
@@ -84,13 +99,26 @@ namespace Rollbar
 
         #region IRollbar
 
+        /// <summary>
+        /// Gets the logger.
+        /// </summary>
+        /// <value>The logger.</value>
         public IAsyncLogger Logger => this;
 
+        /// <summary>
+        /// Gets the configuration.
+        /// </summary>
+        /// <value>The configuration.</value>
         public IRollbarConfig Config
         {
             get { return this._config; }
         }
 
+        /// <summary>
+        /// Configures the using specified settings.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>IRollbar.</returns>
         public IRollbar Configure(IRollbarConfig settings)
         {
             this._config.Reconfigure(settings);
@@ -98,6 +126,11 @@ namespace Rollbar
             return this;
         }
 
+        /// <summary>
+        /// Configures using the specified access token.
+        /// </summary>
+        /// <param name="accessToken">The access token.</param>
+        /// <returns>IRollbar.</returns>
         public IRollbar Configure(string accessToken)
         {
             return this.Configure(new RollbarConfig(accessToken));
@@ -107,42 +140,89 @@ namespace Rollbar
 
         #region IAsyncLogger
 
+        /// <summary>
+        /// Returns blocking/synchronous implementation of this ILogger.
+        /// </summary>
+        /// <param name="timeout">The timeout.</param>
+        /// <returns>ILogger.</returns>
         public ILogger AsBlockingLogger(TimeSpan timeout)
         {
             return new RollbarLoggerBlockingWrapper(this, timeout);
         }
 
+        /// <summary>
+        /// Logs the specified Rollbar Data DTO.
+        /// </summary>
+        /// <param name="rollbarData">The Rollbar Data DTO.</param>
+        /// <returns>Task.</returns>
         public Task Log(DTOs.Data rollbarData)
         {
             return this.EnqueueAsync(rollbarData, rollbarData.Level.HasValue ? rollbarData.Level.Value : ErrorLevel.Debug, null);
         }
 
+        /// <summary>
+        /// Logs using the specified level.
+        /// </summary>
+        /// <param name="level">The level.</param>
+        /// <param name="obj">The object.</param>
+        /// <param name="custom">The custom.</param>
+        /// <returns>Task.</returns>
         public Task Log(ErrorLevel level, object obj, IDictionary<string, object> custom = null)
         {
             return this.EnqueueAsync(obj, level, custom);
         }
 
 
+        /// <summary>
+        /// Logs the specified object as using critical level.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <param name="custom">The custom.</param>
+        /// <returns>Task.</returns>
         public Task Critical(object obj, IDictionary<string, object> custom = null)
         {
             return this.EnqueueAsync(obj, ErrorLevel.Critical, custom);
         }
 
+        /// <summary>
+        /// Logs the specified object as using error level.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <param name="custom">The custom.</param>
+        /// <returns>Task.</returns>
         public Task Error(object obj, IDictionary<string, object> custom = null)
         {
             return this.EnqueueAsync(obj, ErrorLevel.Error, custom);
         }
 
+        /// <summary>
+        /// Logs the specified object as using warning level.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <param name="custom">The custom.</param>
+        /// <returns>Task.</returns>
         public Task Warning(object obj, IDictionary<string, object> custom = null)
         {
             return this.EnqueueAsync(obj, ErrorLevel.Warning, custom);
         }
 
+        /// <summary>
+        /// Logs the specified object as using informational level.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <param name="custom">The custom.</param>
+        /// <returns>Task.</returns>
         public Task Info(object obj, IDictionary<string, object> custom = null)
         {
             return this.EnqueueAsync(obj, ErrorLevel.Info, custom);
         }
 
+        /// <summary>
+        /// Logs the specified object as using debug level.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <param name="custom">The custom.</param>
+        /// <returns>Task.</returns>
         public Task Debug(object obj, IDictionary<string, object> custom = null)
         {
             return this.EnqueueAsync(obj, ErrorLevel.Debug, custom);
@@ -152,20 +232,41 @@ namespace Rollbar
 
         #region IRollbar explicitly
 
+        /// <summary>
+        /// Gets the configuration.
+        /// </summary>
+        /// <value>The configuration.</value>
         IRollbarConfig IRollbar.Config { get { return this.Config; } }
 
+        /// <summary>
+        /// Gets the logger.
+        /// </summary>
+        /// <value>The logger.</value>
         IAsyncLogger IRollbar.Logger { get { return this; } }
 
+        /// <summary>
+        /// Configures the using specified settings.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>IRollbar.</returns>
         IRollbar IRollbar.Configure(IRollbarConfig settings)
         {
             return this.Configure(settings);
         }
 
+        /// <summary>
+        /// Configures using the specified access token.
+        /// </summary>
+        /// <param name="accessToken">The access token.</param>
+        /// <returns>IRollbar.</returns>
         IRollbar IRollbar.Configure(string accessToken)
         {
             return this.Configure(accessToken);
         }
 
+        /// <summary>
+        /// Occurs when a Rollbar internal event happens.
+        /// </summary>
         event EventHandler<RollbarEventArgs> IRollbar.InternalEvent
         {
             add
@@ -183,37 +284,79 @@ namespace Rollbar
 
         #region IAsyncLogger explicitly
 
+        /// <summary>
+        /// Returns as the blocking logger.
+        /// </summary>
+        /// <param name="timeout">The timeout.</param>
+        /// <returns>ILogger.</returns>
         ILogger IAsyncLogger.AsBlockingLogger(TimeSpan timeout)
         {
             return this.AsBlockingLogger(timeout);
         }
 
+        /// <summary>
+        /// Logs using the specified level.
+        /// </summary>
+        /// <param name="level">The level.</param>
+        /// <param name="obj">The object.</param>
+        /// <param name="custom">The custom.</param>
+        /// <returns>Task.</returns>
         Task IAsyncLogger.Log(ErrorLevel level, object obj, IDictionary<string, object> custom)
         {
             return this.Log(level, obj, custom);
         }
 
 
+        /// <summary>
+        /// Logs the specified object as using critical level.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <param name="custom">The custom.</param>
+        /// <returns>Task.</returns>
         Task IAsyncLogger.Critical(object obj, IDictionary<string, object> custom)
         {
             return this.Critical(obj, custom);
         }
 
+        /// <summary>
+        /// Logs the specified object as using error level.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <param name="custom">The custom.</param>
+        /// <returns>Task.</returns>
         Task IAsyncLogger.Error(object obj, IDictionary<string, object> custom)
         {
             return this.Error(obj, custom);
         }
 
+        /// <summary>
+        /// Logs the specified object as using warning level.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <param name="custom">The custom.</param>
+        /// <returns>Task.</returns>
         Task IAsyncLogger.Warning(object obj, IDictionary<string, object> custom)
         {
             return this.Warning(obj, custom);
         }
 
+        /// <summary>
+        /// Logs the specified object as using informational level.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <param name="custom">The custom.</param>
+        /// <returns>Task.</returns>
         Task IAsyncLogger.Info(object obj, IDictionary<string, object> custom)
         {
             return this.Info(obj, custom);
         }
 
+        /// <summary>
+        /// Logs the specified object as using debug level.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <param name="custom">The custom.</param>
+        /// <returns>Task.</returns>
         Task IAsyncLogger.Debug(object obj, IDictionary<string, object> custom)
         {
             return this.Debug(obj, custom);
@@ -292,7 +435,7 @@ namespace Rollbar
         {
             lock (this._syncRoot)
             {
-                var data = RollbarUtil.PackageAsPayloadData(utcTimestamp, this.Config, level, dataObject, custom); //new Data(this._config, body, custom);
+                var data = RollbarUtil.PackageAsPayloadData(utcTimestamp, this.Config, level, dataObject, custom);
                 var payload = new Payload(this._config.AccessToken, data, timeoutAt, signal);
                 DoSend(payload);
             }

--- a/Rollbar/RollbarLoggerBlockingWrapper.cs
+++ b/Rollbar/RollbarLoggerBlockingWrapper.cs
@@ -7,7 +7,6 @@ namespace Rollbar
     using System;
     using System.Collections.Generic;
     using System.Threading;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// 
@@ -63,6 +62,11 @@ namespace Rollbar
 
         #region ILogger
 
+        /// <summary>
+        /// Returns blocking/synchronous implementation of this ILogger.
+        /// </summary>
+        /// <param name="timeout">The timeout.</param>
+        /// <returns>ILogger.</returns>
         public ILogger AsBlockingLogger(TimeSpan timeout)
         {
             return new RollbarLoggerBlockingWrapper(this._asyncLogger, timeout);
@@ -74,6 +78,13 @@ namespace Rollbar
             return this;
         }
 
+        /// <summary>
+        /// Logs using the specified level.
+        /// </summary>
+        /// <param name="level">The level.</param>
+        /// <param name="obj">The object.</param>
+        /// <param name="custom">The custom data.</param>
+        /// <returns>ILogger.</returns>
         public ILogger Log(ErrorLevel level, object obj, IDictionary<string, object> custom = null)
         {
             if (this._asyncLogger.Config.LogLevel.HasValue && level < this._asyncLogger.Config.LogLevel.Value)
@@ -86,62 +97,62 @@ namespace Rollbar
             return this;
         }
 
+        /// <summary>
+        /// Logs the specified object as critical.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <param name="custom">The custom data.</param>
+        /// <returns>ILogger.</returns>
         public ILogger Critical(object obj, IDictionary<string, object> custom = null)
         {
             return this.Log(ErrorLevel.Critical, obj, custom);
         }
 
+        /// <summary>
+        /// Logs the specified object as error.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <param name="custom">The custom data.</param>
+        /// <returns>ILogger.</returns>
         public ILogger Error(object obj, IDictionary<string, object> custom = null)
         {
             return this.Log(ErrorLevel.Error, obj, custom);
         }
 
+        /// <summary>
+        /// Logs the specified object as warning.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <param name="custom">The custom data.</param>
+        /// <returns>ILogger.</returns>
         public ILogger Warning(object obj, IDictionary<string, object> custom = null)
         {
             return this.Log(ErrorLevel.Warning, obj, custom);
         }
 
+        /// <summary>
+        /// Logs the specified object as info.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <param name="custom">The custom data.</param>
+        /// <returns>ILogger.</returns>
         public ILogger Info(object obj, IDictionary<string, object> custom = null)
         {
             return this.Log(ErrorLevel.Info, obj, custom);
         }
 
+        /// <summary>
+        /// Logs the specified object as debug.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <param name="custom">The custom data.</param>
+        /// <returns>ILogger.</returns>
         public ILogger Debug(object obj, IDictionary<string, object> custom = null)
         {
             return this.Log(ErrorLevel.Debug, obj, custom);
         }
 
         #endregion ILogger
-
-        //#region IRollbar
-
-        //public ILogger Logger => this;
-
-        //public IRollbarConfig Config
-        //{
-        //    get { return this._asyncLogger.Config; }
-        //}
-
-        //public IRollbar Configure(IRollbarConfig settings)
-        //{
-        //    Assumption.AssertNotNull(settings, nameof(settings));
-        //    this._asyncLogger.Config.Reconfigure(settings);
-
-        //    return this;
-        //}
-
-        //public IRollbar Configure(string accessToken)
-        //{
-        //    return this.Configure(new RollbarConfig(accessToken));
-        //}
-
-        //public event EventHandler<RollbarEventArgs> InternalEvent
-        //{
-        //    add { this._asyncLogger.InternalEvent += value; }
-        //    remove { this._asyncLogger.InternalEvent -= value; }
-        //}
-
-        //#endregion IRollbar
 
         #region IDisposable Support
 

--- a/Rollbar/Telemetry/TelemetryConfig.cs
+++ b/Rollbar/Telemetry/TelemetryConfig.cs
@@ -113,41 +113,9 @@
             this.TelemetryAutoCollectionTypes = TelemetryType.None;
             this.TelemetryAutoCollectionInterval = TimeSpan.Zero;
 
-#if NETFX
-            // initialize based on app.config settings of Rollbar section (if any):
-            this.InitFromAppConfig();
-#endif
+            // initialize based on application configuration file (if any):
+            NetStandard.RollbarConfigUtil.Load(this);
         }
-
-#if NETFX
-        private void InitFromAppConfig()
-        {
-            Rollbar.NetFramework.RollbarTelemetryConfigSection config =
-                Rollbar.NetFramework.RollbarTelemetryConfigSection.GetConfiguration();
-            if (config == null)
-            {
-                return;
-            }
-
-            if (config.TelemetryEnabled.HasValue)
-            {
-                this.TelemetryEnabled = config.TelemetryEnabled.Value;
-            }
-            if (config.TelemetryQueueDepth.HasValue)
-            {
-                this.TelemetryQueueDepth = config.TelemetryQueueDepth.Value;
-            }
-            if (config.TelemetryAutoCollectionTypes.HasValue)
-            {
-                this.TelemetryAutoCollectionTypes = config.TelemetryAutoCollectionTypes.Value;
-            }
-            if (config.TelemetryAutoCollectionInterval.HasValue)
-            {
-                this.TelemetryAutoCollectionInterval = config.TelemetryAutoCollectionInterval.Value;
-            }
-
-        }
-#endif
 
     }
 }

--- a/Sample.PlugIns.Log4net/ReadMe.md
+++ b/Sample.PlugIns.Log4net/ReadMe.md
@@ -30,5 +30,5 @@ Have fun taking advantages for Rollbar Dashboard while monitoring behavior of yo
 adding the Rollbar support to your products)!
 
 Here is an example of an error log from this sample rendered within the Rollbar Dashboard:
-https://rollbar.com/Rollbar/Rollbar.Net/items/612/occurrences/59671813374/
+https://rollbar.com/Rollbar/Rollbar.Net/items/612/occurrences/61156595528/
 

--- a/Sample.PlugIns.NLog/ReadMe.md
+++ b/Sample.PlugIns.NLog/ReadMe.md
@@ -30,7 +30,7 @@ Have fun taking advantages for Rollbar Dashboard while monitoring behavior of yo
 adding the Rollbar support to your products)!
 
 Here is an example of an error log from this sample rendered within the Rollbar Dashboard:
-https://rollbar.com/Rollbar/Rollbar.Net/items/625/occurrences/61008279723/
+https://rollbar.com/Rollbar/Rollbar.Net/items/625/occurrences/61156681839/
 
 
 

--- a/Sample.PlugIns.NLog/ReadMe.md
+++ b/Sample.PlugIns.NLog/ReadMe.md
@@ -30,6 +30,7 @@ Have fun taking advantages for Rollbar Dashboard while monitoring behavior of yo
 adding the Rollbar support to your products)!
 
 Here is an example of an error log from this sample rendered within the Rollbar Dashboard:
-https://rollbar.com/Rollbar/Rollbar.Net/items/625/occurrences/59982613008/
+https://rollbar.com/Rollbar/Rollbar.Net/items/625/occurrences/61008279723/
+
 
 

--- a/Sample.PlugIns.Serilog/ReadMe.md
+++ b/Sample.PlugIns.Serilog/ReadMe.md
@@ -18,6 +18,6 @@ In this example, we have a very simple .NET Core console application that alread
 Have fun taking advantages for Rollbar Dashboard while monitoring behavior of your products!
 
 Here is an example of an error log from this sample rendered within the Rollbar Dashboard:
-https://rollbar.com/Rollbar/Rollbar.Net/items/610/occurrences/60084806017/
+https://rollbar.com/Rollbar/Rollbar.Net/items/610/occurrences/61157626397/
 
 

--- a/Sample.PlugIns.Serilog/ReadMe.md
+++ b/Sample.PlugIns.Serilog/ReadMe.md
@@ -18,6 +18,6 @@ In this example, we have a very simple .NET Core console application that alread
 Have fun taking advantages for Rollbar Dashboard while monitoring behavior of your products!
 
 Here is an example of an error log from this sample rendered within the Rollbar Dashboard:
-https://rollbar.com/Rollbar/Rollbar.Net/items/610/occurrences/59676906041/
+https://rollbar.com/Rollbar/Rollbar.Net/items/610/occurrences/60084806017/
 
 

--- a/SolutionCommon.csproj
+++ b/SolutionCommon.csproj
@@ -8,10 +8,12 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     -->
 
-    <NotifierVersion>2.0.2</NotifierVersion>
+    <NotifierVersion>2.1.0</NotifierVersion>
     <PackageReleaseNotes>
       Improvements and fixes:
-      - ref #227: Factor out common code pattern of PlugIns
+      - resolve #229: Improve loading of RollbarConfig from JSON and XML
+      - resolve #168: Consider simplifying SDK multi-targeting by moving to .NET Standard shared base
+      - resolve #227: Factor out common code pattern of PlugIns
       - resolve #225: Make Rollbar.NET available as NLog target
     </PackageReleaseNotes>
 
@@ -38,41 +40,48 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Rollbar.xml</DocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <PropertyGroup Condition="
+                 '$(TargetFramework)' == 'netstandard2.0'
+                 ">
     <NetVariant>NET_STANDARD</NetVariant>
     <DefineConstants>NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'
-                 Or '$(TargetFramework)' == 'netcoreapp2.0'">
+  <PropertyGroup Condition="
+                 '$(TargetFramework)' == 'netcoreapp2.1'
+                 Or '$(TargetFramework)' == 'netcoreapp2.0'
+                 ">
     <NetVariant>NET_CORE</NetVariant>
     <DefineConstants>NETCOREAPP</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'
-             Or '$(TargetFramework)' == 'net471'
-             Or '$(TargetFramework)' == 'net47' 
-             Or '$(TargetFramework)' == 'net462' 
-             Or '$(TargetFramework)' == 'net461' 
-             Or '$(TargetFramework)' == 'net46'
-             Or '$(TargetFramework)' == 'net452'
-             Or '$(TargetFramework)' == 'net451'
-             Or '$(TargetFramework)' == 'net45'
-             ">
+  <PropertyGroup Condition="
+                 '$(TargetFramework)' == 'net472'
+                 Or '$(TargetFramework)' == 'net471'
+                 Or '$(TargetFramework)' == 'net47' 
+                 Or '$(TargetFramework)' == 'net462' 
+                 Or '$(TargetFramework)' == 'net461' 
+                 Or '$(TargetFramework)' == 'net46'
+                 Or '$(TargetFramework)' == 'net452'
+                 Or '$(TargetFramework)' == 'net451'
+                 Or '$(TargetFramework)' == 'net45'
+                 ">
     <NetVariant>NET_FX</NetVariant>
     <DefineConstants>NETFX</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net46'
-             Or '$(TargetFramework)' == 'net452'
-             Or '$(TargetFramework)' == 'net451'
-             Or '$(TargetFramework)' == 'net45'
-             ">
+  <PropertyGroup Condition="
+                 '$(TargetFramework)' == 'net46'
+                 Or '$(TargetFramework)' == 'net452'
+                 Or '$(TargetFramework)' == 'net451'
+                 Or '$(TargetFramework)' == 'net45'
+                 ">
     <DefineConstants>NETFX_46nOlder;NETFX</DefineConstants>
   </PropertyGroup>
 
 
-  <ItemGroup Condition="'$(NetVariant)' == 'NET_CORE' 
+  <ItemGroup Condition="
+             '$(NetVariant)' == 'NET_CORE' 
              Or '$(NetVariant)' == 'NET_STANDARD'
              ">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
@@ -85,7 +94,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(NetVariant)' == 'NET_FX'">
+  <ItemGroup Condition="
+             '$(NetVariant)' == 'NET_FX'
+             ">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />

--- a/SolutionCommon.csproj
+++ b/SolutionCommon.csproj
@@ -11,6 +11,7 @@
     <NotifierVersion>2.1.0</NotifierVersion>
     <PackageReleaseNotes>
       Improvements and fixes:
+      - resolve #230: Make sure payload's Data timestamp corresponds object capture moment instead of Data packaging moment on another thread
       - resolve #229: Improve loading of RollbarConfig from JSON and XML
       - resolve #168: Consider simplifying SDK multi-targeting by moving to .NET Standard shared base
       - resolve #227: Factor out common code pattern of PlugIns

--- a/SolutionCommon.csproj
+++ b/SolutionCommon.csproj
@@ -10,10 +10,9 @@
 
     <NotifierVersion>2.0.2</NotifierVersion>
     <PackageReleaseNotes>
-
       Improvements and fixes:
+      - ref #227: Factor out common code pattern of PlugIns
       - resolve #225: Make Rollbar.NET available as NLog target
-      
     </PackageReleaseNotes>
 
     <Version>$(NotifierVersion)</Version>

--- a/SolutionCommon.csproj
+++ b/SolutionCommon.csproj
@@ -11,6 +11,8 @@
     <NotifierVersion>2.1.0</NotifierVersion>
     <PackageReleaseNotes>
       Improvements and fixes:
+      - resolve #224: Rollbar does not honor proxy settings when initialized from code
+      - resolve #228: Make RollbarLogger fully reconfigurable (including its critical attributes)
       - resolve #230: Make sure payload's Data timestamp corresponds object capture moment instead of Data packaging moment on another thread
       - resolve #229: Improve loading of RollbarConfig from JSON and XML
       - resolve #168: Consider simplifying SDK multi-targeting by moving to .NET Standard shared base


### PR DESCRIPTION
      Improvements and fixes:
      - resolve #224: Rollbar does not honor proxy settings when initialized from code
      - resolve #228: Make RollbarLogger fully reconfigurable (including its critical attributes)
      - resolve #230: Make sure payload's Data timestamp corresponds object capture moment instead of Data packaging moment on another thread
      - resolve #229: Improve loading of RollbarConfig from JSON and XML
      - resolve #168: Consider simplifying SDK multi-targeting by moving to .NET Standard shared base
      - resolve #227: Factor out common code pattern of PlugIns
      - resolve #225: Make Rollbar.NET available as NLog target
