### PR TITLE
resolve #292

### DIFF
--- a/Rollbar/DTOs/Frame.cs
+++ b/Rollbar/DTOs/Frame.cs
@@ -186,7 +186,12 @@
             {
                 returnVal = method.ReflectedType.FullName ;
             }
-            return returnVal;
+            if (!string.IsNullOrWhiteSpace(returnVal))
+            {
+                return returnVal;
+            }
+
+            return defaultFileName;
         }
 
         private static int? GetLineNumber(StackFrame frame)

--- a/SolutionCommon.csproj
+++ b/SolutionCommon.csproj
@@ -8,25 +8,10 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     -->
 
-    <NotifierVersion>2.2.1</NotifierVersion>
+    <NotifierVersion>2.2.2</NotifierVersion>
     <PackageReleaseNotes>
-      Improvements and fixes:
-      - resolve #284: ReconfigurableBase&lt;T&gt;: Override 'Equals(object)'.
-      - resolve #283: ReconfigurableBase&lt;T, TBase&gt;: Override 'Equals(object)'.
-      - resolve #277: Implement all Codacy recommendations after its rules are tuned and configured.
-      - resolve #276: Analyze, tune Codacy rules and settings for the project's codebase.
-      - resolve #275: Complete Codacy integration.
-      - resolve #266: Create sample for Rollbar.PlugIns.MSEnterpriseLibrary.
-      - resolve #272: Factor out unit test base that initializes/disposes Rollbar instance and verifies successful transmissions.
-      - resolve #273: Provide API to check equality of two RollbarConfig objects (property-by-property).
-      - resolve #271: Factor out shared RollbarUnitTestSettings.
-      - resolve #270: Setup unit tests for Rollbar.PlugIns.Serilog.
-      - resolve #269: Setup unit tests for Rollbar.PlugIns.NLog.
-      - resolve #268: Setup unit tests for Rollbar.PlugIns.Log4net.
-      - ref #237: Rollbar plug-in for Microsoft Enterprise Library.
-      - resolve #254: Missing web.config crashes RollbarConfig constructor method.
-      - ref #244: Fix crash when no hosting application configuration file is present.
-      - minor Samples improvements
+      Hot-fix:
+      - resolve #292: Missing exception frame filename causes payload transmission failure.
     </PackageReleaseNotes>
 
     <Version>$(NotifierVersion)</Version>


### PR DESCRIPTION
      - resolve #292: Missing exception frame filename causes payload transmission failure.