### PR TITLE
Release candidate for v3.0.4

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,4 @@
-# v3.0.3 Rollbar.NET Notifier SDK Release Notes
+# v3.0.4 Rollbar.NET Notifier SDK Release Notes
 
 ## Upgrade Notes
 
@@ -55,6 +55,12 @@ Each of the modules is available via NuGet as stand-alone package.
 We are also unifying versioning all of the modules to follow common SDK versioning. 
 
 ### Fixes and Improvements
+
+#### v3.0.4
+-   resolve #355: AddRollbar() is missing in release 3.0.3
+-   resolve #367: Extra fail-safe guards when processing faulty payload bundles within the queues
+-   resolve #369: Change default rate limit to 5K per minute
+-   ref #352: Increase Core's unit test coverage around recovery from invalid payloads and failures
 
 #### v3.0.3
 -	resolve #352: Create automated release build script

--- a/Rollbar/ConfigAttributesPackageDecorator.cs
+++ b/Rollbar/ConfigAttributesPackageDecorator.cs
@@ -66,6 +66,11 @@
         /// <param name="rollbarData">The rollbar data.</param>
         protected override void Decorate(Data rollbarData)
         {
+            if (rollbarData == null)
+            {
+                return; //nothing to decorate...
+            }
+
             // telemetry data is based on the configuration,
             // so let's include it if applicable:
             if (this._capturedTelemetryRecords != null)

--- a/Rollbar/InternalRollbarError.cs
+++ b/Rollbar/InternalRollbarError.cs
@@ -30,6 +30,11 @@
         EnqueuingError,
 
         /// <summary>
+        /// The dequeuing error
+        /// </summary>
+        DequeuingError,
+
+        /// <summary>
         /// The payload check ignore error
         /// </summary>
         PayloadCheckIgnoreError,

--- a/Rollbar/PayloadQueue.cs
+++ b/Rollbar/PayloadQueue.cs
@@ -3,22 +3,47 @@
 namespace Rollbar
 {
     using Rollbar.Diagnostics;
-    using Rollbar.DTOs;
     using System;
     using System.Collections.Generic;
 
+    /// <summary>
+    /// Class PayloadQueue.
+    /// </summary>
     internal class PayloadQueue
     {
+        /// <summary>
+        /// The synchronize lock
+        /// </summary>
         private readonly object _syncLock;
+        /// <summary>
+        /// The queue
+        /// </summary>
         private readonly Queue<PayloadBundle> _queue;
+        /// <summary>
+        /// The logger
+        /// </summary>
         private readonly RollbarLogger _logger;
+        /// <summary>
+        /// The client
+        /// </summary>
         private RollbarClient _client;
+        /// <summary>
+        /// The is released
+        /// </summary>
         private bool _isReleased;
 
+        /// <summary>
+        /// Prevents a default instance of the <see cref="PayloadQueue"/> class from being created.
+        /// </summary>
         private PayloadQueue()
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PayloadQueue"/> class.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="client">The client.</param>
         public PayloadQueue(RollbarLogger logger, RollbarClient client)
         {
             Assumption.AssertNotNull(logger, nameof(logger));
@@ -32,21 +57,40 @@ namespace Rollbar
             this._isReleased = false;
         }
 
+        /// <summary>
+        /// Releases this instance.
+        /// </summary>
         public void Release()
         {
             Assumption.AssertFalse(this._isReleased, nameof(this._isReleased));
             this._isReleased = true;
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this instance is released.
+        /// </summary>
+        /// <value><c>true</c> if this instance is released; otherwise, <c>false</c>.</value>
         public bool IsReleased { get { return this._isReleased; } }
 
+        /// <summary>
+        /// Gets or sets the next dequeue time.
+        /// </summary>
+        /// <value>The next dequeue time.</value>
         public DateTimeOffset NextDequeueTime { get; internal set; }
 
+        /// <summary>
+        /// Gets the logger.
+        /// </summary>
+        /// <value>The logger.</value>
         public RollbarLogger Logger
         {
             get { return this._logger; }
         }
 
+        /// <summary>
+        /// Updates the client.
+        /// </summary>
+        /// <param name="client">The client.</param>
         public void UpdateClient(RollbarClient client)
         {
             if (this._client == client)
@@ -60,14 +104,27 @@ namespace Rollbar
             }
         }
 
+        /// <summary>
+        /// Gets the client.
+        /// </summary>
+        /// <value>The client.</value>
         public RollbarClient Client
         {
             get { return this._client; }
         }
 
+        /// <summary>
+        /// Enqueues the specified payload.
+        /// </summary>
+        /// <param name="payload">The payload.</param>
         public void Enqueue(PayloadBundle payload)
         {
             Assumption.AssertNotNull(payload, nameof(payload));
+
+            if (payload == null)
+            {
+                return; // no one needs to enqueue "nothing"... 
+            }
 
             lock (this._syncLock)
             {
@@ -79,6 +136,10 @@ namespace Rollbar
             }
         }
 
+        /// <summary>
+        /// Peeks this instance.
+        /// </summary>
+        /// <returns>PayloadBundle, if any, otherwise null.</returns>
         public PayloadBundle Peek()
         {
             lock(this._syncLock)
@@ -94,6 +155,10 @@ namespace Rollbar
             }
         }
 
+        /// <summary>
+        /// Dequeues this instance.
+        /// </summary>
+        /// <returns>PayloadBundle, if any, otherwise null.</returns>
         public PayloadBundle Dequeue()
         {
             lock (this._syncLock)
@@ -114,6 +179,10 @@ namespace Rollbar
             }
         }
 
+        /// <summary>
+        /// Gets the payload count.
+        /// </summary>
+        /// <returns>System.Int32.</returns>
         public int GetPayloadCount()
         {
             lock (this._syncLock)
@@ -122,6 +191,9 @@ namespace Rollbar
             }
         }
 
+        /// <summary>
+        /// Flushes this instance.
+        /// </summary>
         public void Flush()
         {
             lock (this._syncLock)

--- a/Rollbar/RollbarConfig.cs
+++ b/Rollbar/RollbarConfig.cs
@@ -72,7 +72,7 @@
             // let's set some default values:
             this.Environment = "production";
             this.Enabled = true;
-            this.MaxReportsPerMinute = 60;
+            this.MaxReportsPerMinute = 5000;
             this.ReportingQueueDepth = 20;
             this.MaxItems = 0;
             this.CaptureUncaughtExceptions = true;

--- a/Rollbar/RollbarEventArgs.cs
+++ b/Rollbar/RollbarEventArgs.cs
@@ -2,6 +2,7 @@
 {
     using Newtonsoft.Json;
     using System;
+    using System.Diagnostics;
     using System.Text;
 
     /// <summary>
@@ -36,7 +37,14 @@
             this._logger = logger;
             if (dataObject != null)
             {
-                this.Payload = JsonConvert.SerializeObject(dataObject);
+                try
+                {
+                    this.Payload = JsonConvert.SerializeObject(dataObject);
+                }
+                catch (Exception ex)
+                {
+                    Trace.WriteLine(ex, $"{nameof(RollbarEventArgs)}.{nameof(this.Payload)}");
+                }
             }
         }
 

--- a/Rollbar/RollbarQueueController.cs
+++ b/Rollbar/RollbarQueueController.cs
@@ -81,7 +81,7 @@ namespace Rollbar
         /// <summary>
         /// The sleep interval
         /// </summary>
-        internal readonly TimeSpan _sleepInterval = TimeSpan.FromMilliseconds(500);
+        internal readonly TimeSpan _sleepInterval = TimeSpan.FromMilliseconds(25);
         /// <summary>
         /// The total retries
         /// </summary>

--- a/SdkCommon.csproj
+++ b/SdkCommon.csproj
@@ -10,6 +10,7 @@
   <SdkVersion>3.0.4</SdkVersion>
     <PackageReleaseNotes>
       - resolve #355: AddRollbar() is missing in release 3.0.3
+      - resolve #367: Extra fail-safe guards when processing faulty payload bundles within the queues
       - ref #352: Increase Core's unit test coverage around recovery from invalid payloads and failures
     </PackageReleaseNotes>
     <Version>$(SdkVersion)</Version>

--- a/SdkCommon.csproj
+++ b/SdkCommon.csproj
@@ -11,6 +11,7 @@
     <PackageReleaseNotes>
       - resolve #355: AddRollbar() is missing in release 3.0.3
       - resolve #367: Extra fail-safe guards when processing faulty payload bundles within the queues
+      - resolve #369: Change default rate limit to 5K per minute
       - ref #352: Increase Core's unit test coverage around recovery from invalid payloads and failures
     </PackageReleaseNotes>
     <Version>$(SdkVersion)</Version>

--- a/UnitTest.Rollbar/Mocks/FaultyPackage.cs
+++ b/UnitTest.Rollbar/Mocks/FaultyPackage.cs
@@ -1,0 +1,37 @@
+﻿namespace UnitTest.Rollbar.Mocks
+{
+    using global::Rollbar;
+    using global::Rollbar.DTOs;
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    /// <summary>
+    /// Class FaultyPackage mock.
+    /// Implements the <see cref="Rollbar.RollbarPackageBase" />
+    /// It throws an exception during data packaging operation.
+    /// </summary>
+    /// <seealso cref="Rollbar.RollbarPackageBase" />
+    public class FaultyPackage
+        : RollbarPackageBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FaultyPackage"/> class.
+        /// </summary>
+        /// <param name="mustApplySynchronously">if set to <c>true</c> the strategy must be apply synchronously.</param>
+        public FaultyPackage(bool mustApplySynchronously) 
+            : base(mustApplySynchronously)
+        {
+        }
+
+        /// <summary>
+        /// Produces the rollbar data.
+        /// </summary>
+        /// <returns>Rollbar Data DTO or null (if packaging is not applicable in some cases).</returns>
+        /// <exception cref="NotImplementedException">Intentionally faulty package for unit testing!</exception>
+        protected override Data ProduceRollbarData()
+        {
+            throw new NotImplementedException("Intentionally faulty package for unit testing!");
+        }
+    }
+}

--- a/UnitTest.Rollbar/Mocks/NothingPackage.cs
+++ b/UnitTest.Rollbar/Mocks/NothingPackage.cs
@@ -1,0 +1,36 @@
+﻿namespace UnitTest.Rollbar.Mocks
+{
+    using global::Rollbar;
+    using global::Rollbar.DTOs;
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    /// <summary>
+    /// Class NothingPackage.
+    /// Implements the <see cref="Rollbar.RollbarPackageBase" />
+    /// Produces null Data during packaging operation.
+    /// </summary>
+    /// <seealso cref="Rollbar.RollbarPackageBase" />
+    public class NothingPackage
+        : RollbarPackageBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NothingPackage"/> class.
+        /// </summary>
+        /// <param name="mustApplySynchronously">if set to <c>true</c> the strategy must be apply synchronously.</param>
+        public NothingPackage(bool mustApplySynchronously) 
+            : base(mustApplySynchronously)
+        {
+        }
+
+        /// <summary>
+        /// Produces the rollbar data.
+        /// </summary>
+        /// <returns>Rollbar Data DTO or null (if packaging is not applicable in some cases).</returns>
+        protected override Data ProduceRollbarData()
+        {
+            return null;
+        }
+    }
+}

--- a/UnitTest.Rollbar/RollbarLiveFixtureBase.cs
+++ b/UnitTest.Rollbar/RollbarLiveFixtureBase.cs
@@ -151,8 +151,15 @@ namespace UnitTest.Rollbar
             this.InternalSdkErrorEvents.Clear();
         }
 
+        private void MakeSureAllThePayloadsProcessed()
+        {
+            Thread.Sleep(RollbarQueueController.Instance.GetRecommendedTimeout().Add(TimeSpan.FromSeconds(1)));
+            Assert.AreEqual(0, RollbarQueueController.Instance.GetTotalPayloadCount(), "All the payloads are expected to be out of the queues...");
+        }
         private void VerifyActualEventsAgainstExpectedTotals()
         {
+            MakeSureAllThePayloadsProcessed();
+
             Assert.AreEqual(this.ExpectedCommunicationEventsTotal, this.CommunicationEvents.Count, "Actual CommunicationEvents count does not match expectation.");
             Assert.IsTrue(
                 // EITHER no errors expected:
@@ -216,7 +223,8 @@ namespace UnitTest.Rollbar
 
         protected void VerifyInstanceOperational(IRollbar rollbar)
         {
-            Thread.Sleep(RollbarQueueController.Instance.GetRecommendedTimeout());
+            MakeSureAllThePayloadsProcessed();
+
             //Assert.IsTrue(0 == RollbarQueueController.Instance.GetTotalPayloadCount(), "Making sure all the queues are clear...");
             int initialCommunicationEventsCount = this.ActualComunicationEventsCount;
             this.ExpectedCommunicationEventsTotal++;

--- a/UnitTest.Rollbar/RollbarLoggerFixture.cs
+++ b/UnitTest.Rollbar/RollbarLoggerFixture.cs
@@ -34,6 +34,7 @@ namespace UnitTest.Rollbar
         }
 
         #region failure recovery tests
+
         /// <summary>
         /// Main purpose of these tests is to make sure that no Rollbar.NET usage scenario encountering an error
         /// brings down or halts the RollbarLogger operation.
@@ -43,6 +44,17 @@ namespace UnitTest.Rollbar
         /// - exception within a packager or package decorator,
         /// - TBD...
         /// </summary>
+        /// 
+
+        public void InvalidPayloadDataTest()
+        {
+            //TODO:
+        }
+
+        public void FaultyPayloadTransformationTest()
+        {
+            //TODO:
+        }
         
         public enum TrickyPackage
         {
@@ -220,8 +232,7 @@ namespace UnitTest.Rollbar
                 try
                 {
                     this.ExpectedCommunicationEventsTotal++;
-                    //TODO: implement and add SynchronousPackage around the payload object!!!
-                    logger.Error(new System.Exception("test exception"));
+                    logger.AsBlockingLogger(defaultRollbarTimeout).Error(new System.Exception("test exception"));
                 }
                 catch
                 {
@@ -246,8 +257,7 @@ namespace UnitTest.Rollbar
                     try
                     {
                         this.ExpectedCommunicationEventsTotal++;
-                        //TODO: implement and add SynchronousPackage around the payload object!!!
-                        logger.Error(new System.Exception("outer exception", ex));
+                        logger.AsBlockingLogger(defaultRollbarTimeout).Error(new System.Exception("outer exception", ex));
                     }
                     catch
                     {
@@ -265,8 +275,7 @@ namespace UnitTest.Rollbar
                 try
                 {
                     this.ExpectedCommunicationEventsTotal++;
-                    //TODO: implement and add SynchronousPackage around the payload object!!!
-                    logger.Log(ErrorLevel.Error, "test message");
+                    logger.AsBlockingLogger(defaultRollbarTimeout).Log(ErrorLevel.Error, "test message");
                 }
                 catch
                 {


### PR DESCRIPTION
Fixes and improvements:      
- resolve #355: AddRollbar() is missing in release 3.0.3
- resolve #367: Extra fail-safe guards when processing faulty payload bundles within the queues
- resolve #369: Change default rate limit to 5K per minute
- ref #352: Increase Core's unit test coverage around recovery from invalid payloads and failures
