### PR TITLE
Fix the "System.ObjectDisposedException: Cannot access a closed Strea…

### DIFF
--- a/Rollbar.NetCore.AspNet/HttpRequestPackageDecorator.cs
+++ b/Rollbar.NetCore.AspNet/HttpRequestPackageDecorator.cs
@@ -97,7 +97,7 @@
                 encoding = Encoding.UTF8;
             }
 
-            using (StreamReader reader = new StreamReader(request.Body, encoding))
+            using (StreamReader reader = new StreamReader(request.Body, encoding, true, 1024, true))
             {
                 return reader.ReadToEnd();
             }


### PR DESCRIPTION
…m." when logging the same HttpRequest twice.

**This implementation is currently untested as I couldn't get this to build on my macOS machine, but the change in constructor was used in my own code**

Issue is when using attempting to log two things with the same HttpRequest you will get a System.ObjectDisposedException thrown due to the StreamReader closing the underlying HttpRequest.Body stream when it is disposed after its using statement.

I came across this because my POST json object was not scrubbed (something for me to double check another day), so I built my own tools to scrub the json. This involved subclassing HttpRequest and then copying required fields from the actual request into this new object and then cloning the body so I can scrub some fields while keeping the original payload in tact.

What I discovered was
```
using (StreamReader reader = new StreamReader(request.Body, encoding))
```
will automatically close the request.Body stream automatically when it disposes, which is pretty quickly. To avoid this you need to access the fifth parameter of the constructor for leaveOpen. The choice of 1024 byte buffer is because it is what this constructor will use by default (mentioned in the [docs](https://docs.microsoft.com/en-us/dotnet/api/system.io.streamreader.-ctor?view=netframework-4.7.2#System_IO_StreamReader__ctor_System_IO_Stream_System_Text_Encoding_System_Boolean_System_Int32_System_Boolean_)). I don't know what the default for detectEncodingFromByteOrderMarks would be, so I made it true.

To cause the exception to be thrown simply try log the same HttpRequest twice, although the problem isn't specific to this situation. It would come up if you log a HttpRequest and then try read its body via request.Body.

```
var rollbarPackage1 = new ExceptionPackage(new Exception("Error 1"));
var packageDecorator1 = new HttpRequestPackageDecorator(rollbarPackage1, this.HttpContext.Request, true);
RollbarLocator.RollbarInstance.Log(ErrorLevel.Error, packageDecorator1);

var rollbarPackage2 = new ExceptionPackage(new Exception("Error 2"));
var packageDecorator2 = new HttpRequestPackageDecorator(rollbarPackage2, this.HttpContext.Request, true);
RollbarLocator.RollbarInstance.Log(ErrorLevel.Error, packageDecorator2);
```

