### PR TITLE
Resolve #368: Make SDK to obey service-side enforced rate limits unless client-side RollbarConfig defines one

### DIFF
--- a/Rollbar.NetCore.AspNet/RollbarMiddleware.cs
+++ b/Rollbar.NetCore.AspNet/RollbarMiddleware.cs
@@ -176,7 +176,6 @@ namespace Rollbar.NetCore.AspNet
                         }
                         networkTelemetry.FinalizeEvent();
                     }
-
                 }
             }
         }

--- a/Rollbar/AccessTokenQueuesMetadata.cs
+++ b/Rollbar/AccessTokenQueuesMetadata.cs
@@ -63,35 +63,6 @@ namespace Rollbar
         public DateTimeOffset NextTimeTokenUsage { get; private set; } = DateTimeOffset.Now;
 
         /// <summary>
-        /// Gets the token usage delay.
-        /// </summary>
-        /// <value>
-        /// The token usage delay.
-        /// </value>
-        public TimeSpan TokenUsageDelay { get; private set; }
-
-        /// <summary>
-        /// Increments the token usage delay.
-        /// </summary>
-        public void IncrementTokenUsageDelay()
-        {
-            this.TokenUsageDelay += AccessTokenQueuesMetadata.accessTokenInitialDelay;
-            DateTimeOffset nextTimeTokenUsageCandidate = DateTimeOffset.Now.Add(this.TokenUsageDelay);
-            if (nextTimeTokenUsageCandidate > this.NextTimeTokenUsage)
-            {
-                this.NextTimeTokenUsage = nextTimeTokenUsageCandidate;
-            }
-        }
-
-        /// <summary>
-        /// Resets the token usage delay.
-        /// </summary>
-        public void ResetTokenUsageDelay()
-        {
-            this.TokenUsageDelay = TimeSpan.Zero;
-        }
-
-        /// <summary>
         /// Updates the next time token usage.
         /// </summary>
         /// <param name="rollbarRateLimit">The rollbar rate limit.</param>
@@ -99,12 +70,20 @@ namespace Rollbar
         {
             if (rollbarRateLimit.WindowRemaining > 0)
             {
+                this.IsTransmissionSuspended = false;
                 this.NextTimeTokenUsage = DateTimeOffset.Now;
             }
             else
             {
+                this.IsTransmissionSuspended = true;
                 this.NextTimeTokenUsage = rollbarRateLimit.ClientSuspensionEnd;
             }
         }
+
+        /// <summary>
+        /// Gets a value indicating whether this instance is transmission suspended.
+        /// </summary>
+        /// <value><c>true</c> if this instance is transmission suspended; otherwise, <c>false</c>.</value>
+        public bool IsTransmissionSuspended { get; private set; }
     }
 }

--- a/Rollbar/AccessTokenQueuesMetadata.cs
+++ b/Rollbar/AccessTokenQueuesMetadata.cs
@@ -89,7 +89,6 @@ namespace Rollbar
         public void ResetTokenUsageDelay()
         {
             this.TokenUsageDelay = TimeSpan.Zero;
-            //this.NextTimeTokenUsage = DateTimeOffset.Now;
         }
 
         /// <summary>

--- a/Rollbar/Common/DateTimeUtil.cs
+++ b/Rollbar/Common/DateTimeUtil.cs
@@ -45,7 +45,7 @@
         /// </summary>
         /// <param name="inputString">The input string.</param>
         /// <param name="dateTimeOffset">The date time offset.</param>
-        /// <returns><c>true</c> if XXXX, <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if was able to parse successfully, <c>false</c> otherwise.</returns>
         public static bool TryParseFromUnixTimestampInSecondsString(string inputString, out DateTimeOffset dateTimeOffset)
         {
             if (long.TryParse(inputString, out long unixTimestamp))

--- a/Rollbar/Common/DateTimeUtil.cs
+++ b/Rollbar/Common/DateTimeUtil.cs
@@ -39,5 +39,23 @@
             timestamp = timestamp.AddSeconds(Convert.ToDouble(unixTimestampInSeconds));
             return timestamp;
         }
+
+        /// <summary>
+        /// Tries the parse from unix timestamp in seconds string.
+        /// </summary>
+        /// <param name="inputString">The input string.</param>
+        /// <param name="dateTimeOffset">The date time offset.</param>
+        /// <returns><c>true</c> if XXXX, <c>false</c> otherwise.</returns>
+        public static bool TryParseFromUnixTimestampInSecondsString(string inputString, out DateTimeOffset dateTimeOffset)
+        {
+            if (long.TryParse(inputString, out long unixTimestamp))
+            {
+                dateTimeOffset = DateTimeUtil.ConvertFromUnixTimestampInSeconds(unixTimestamp);
+                return true;
+            }
+
+            dateTimeOffset = default;
+            return false;
+        }
     }
 }

--- a/Rollbar/Common/HttpHeadersExtension.cs
+++ b/Rollbar/Common/HttpHeadersExtension.cs
@@ -1,0 +1,87 @@
+﻿namespace Rollbar.Common
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http.Headers;
+
+    /// <summary>
+    /// Class HttpHeadersExtension.
+    /// </summary>
+    public static class HttpHeadersExtension
+    {
+        /// <summary>
+        /// The shared empty result
+        /// </summary>
+        private static readonly string[] emptyResult = new string[0];
+
+        /// <summary>
+        /// Gets the header values safely.
+        /// </summary>
+        /// <param name="httpHeaders">The HTTP headers.</param>
+        /// <param name="headerName">Name of the header.</param>
+        /// <returns>IEnumerable&lt;System.String&gt;.</returns>
+        public static IEnumerable<string> GetHeaderValuesSafely(this HttpHeaders httpHeaders, string headerName)
+        {
+            IEnumerable<string> headerValues;
+
+            if (httpHeaders.TryGetValues(headerName, out headerValues))
+            {
+                if (headerValues != null)
+                {
+                    return headerValues;
+                }
+            }
+
+            return emptyResult;
+        }
+
+        /// <summary>
+        /// Gets the last header value safely.
+        /// </summary>
+        /// <param name="httpHeaders">The HTTP headers.</param>
+        /// <param name="headerName">Name of the header.</param>
+        /// <returns>System.String.</returns>
+        public static string GetLastHeaderValueSafely(this HttpHeaders httpHeaders, string headerName)
+        {
+            string headerValue = httpHeaders.GetHeaderValuesSafely(headerName).LastOrDefault();
+            return headerValue;
+        }
+
+        /// <summary>
+        /// Parses the header value safely if any.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="httpHeaders">The HTTP headers.</param>
+        /// <param name="headerName">Name of the header.</param>
+        /// <param name="tryParseHandler">The try parse handler.</param>
+        /// <returns>System.Nullable&lt;T&gt;.</returns>
+        public static T? ParseHeaderValueSafelyIfAny<T>(this HttpHeaders httpHeaders, string headerName, StringUtility.TryParseHandler<T> tryParseHandler) 
+            where T : struct
+        {
+            string stringValue = httpHeaders.GetLastHeaderValueSafely(headerName);
+            return StringUtility.Parse<T>(stringValue, tryParseHandler);
+        }
+
+        /// <summary>
+        /// Parses the header value safely or default.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="httpHeaders">The HTTP headers.</param>
+        /// <param name="headerName">Name of the header.</param>
+        /// <param name="tryParseHandler">The try parse handler.</param>
+        /// <param name="defaultValue">The default value.</param>
+        /// <returns>T.</returns>
+        public static T ParseHeaderValueSafelyOrDefault<T>(this HttpHeaders httpHeaders, string headerName, StringUtility.TryParseHandler<T> tryParseHandler, T defaultValue)
+            where T : struct
+        {
+            T? parsedValue = httpHeaders.ParseHeaderValueSafelyIfAny<T>(headerName, tryParseHandler);
+            if (parsedValue.HasValue)
+            {
+                return parsedValue.Value;
+            }
+
+            return defaultValue;
+        }
+    }
+}

--- a/Rollbar/Common/StringUtility.cs
+++ b/Rollbar/Common/StringUtility.cs
@@ -1,17 +1,66 @@
 ﻿namespace Rollbar.Common
 {
     using Rollbar.Diagnostics;
-    using System;
+    using System.Diagnostics;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Text;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// A utility type aiding in string manipulations.
     /// </summary>
     public static class StringUtility
     {
+        /// <summary>
+        /// Delegate TryParseHandler
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value">The value.</param>
+        /// <param name="result">The result.</param>
+        /// <returns><c>true</c> if value string is valid, <c>false</c> otherwise.</returns>
+        public delegate bool TryParseHandler<T>(string value, out T result);
+
+        /// <summary>
+        /// Either successfully parses the provided string value or returns null.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value">The string value to parse.</param>
+        /// <param name="tryParseHandler">The try parse handler.</param>
+        /// <returns>System.Nullable&lt;T&gt;.</returns>
+        public static T? Parse<T>(string value, TryParseHandler<T> tryParseHandler) where T : struct
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return null;
+            }
+
+            if (tryParseHandler(value, out T result))
+            {
+                return result;
+            }
+
+            Trace.TraceWarning("Invalid value '{0}'", value);
+            return null;
+        }
+
+        /// <summary>
+        /// Either successfully parses the provided string value or returns specified default value.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value">The string value to parse.</param>
+        /// <param name="tryParseHandler">The try parse handler.</param>
+        /// <param name="defaultValue">The default value.</param>
+        /// <returns>T.</returns>
+        public static T ParseOrDefault<T>(string value, TryParseHandler<T> tryParseHandler, T defaultValue) where T : struct
+        {
+            T? result = StringUtility.Parse<T>(value, tryParseHandler);
+            if (result.HasValue)
+            {
+                return result.Value;
+            }
+
+            return defaultValue;
+        }
+
         /// <summary>
         /// Combines the specified substrings using the specified separator.
         /// </summary>

--- a/Rollbar/IRollbarConfig.cs
+++ b/Rollbar/IRollbarConfig.cs
@@ -79,7 +79,7 @@
         /// <value>
         /// The maximum reports per minute.
         /// </value>
-        int MaxReportsPerMinute { get; }
+        int? MaxReportsPerMinute { get; }
 
         /// <summary>
         /// Gets the reporting queue depth.

--- a/Rollbar/PayloadDropEventArgs.cs
+++ b/Rollbar/PayloadDropEventArgs.cs
@@ -1,0 +1,77 @@
+﻿namespace Rollbar
+{
+    using Rollbar.DTOs;
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    /// <summary>
+    /// Class PayloadDropEventArgs.
+    /// Implements the <see cref="Rollbar.RollbarEventArgs" />
+    /// </summary>
+    /// <seealso cref="Rollbar.RollbarEventArgs" />
+    public class PayloadDropEventArgs
+        : RollbarEventArgs
+    {
+        /// <summary>
+        /// Enum DropReason
+        /// </summary>
+        public enum DropReason
+        {
+            /// <summary>
+            /// The ignorable payload
+            /// </summary>
+            IgnorablePayload,
+
+            /// <summary>
+            /// The token suspension
+            /// </summary>
+            TokenSuspension,
+
+            /// <summary>
+            /// All transmission retries failed
+            /// </summary>
+            AllTransmissionRetriesFailed,
+
+            /// <summary>
+            /// The rollbar queue controller flushed queues
+            /// </summary>
+            RollbarQueueControllerFlushedQueues
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PayloadDropEventArgs"/> class.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="payload">The payload.</param>
+        /// <param name="dropReason">The drop reason.</param>
+        internal PayloadDropEventArgs(RollbarLogger logger, Payload payload, DropReason dropReason) 
+            : base(logger, payload)
+        {
+            this.Reason = dropReason;
+        }
+
+        /// <summary>
+        /// Gets the reason.
+        /// </summary>
+        /// <value>The reason.</value>
+        public DropReason Reason
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Traces as string.
+        /// </summary>
+        /// <param name="indent">The indent.</param>
+        /// <returns>String rendering of this instance.</returns>
+        public override string TraceAsString(string indent)
+        {
+            StringBuilder sb = new StringBuilder(base.TraceAsString(indent));
+            sb.AppendLine(indent + "  Drop Reason: " + this.Reason);
+            return sb.ToString();
+        }
+
+    }
+}

--- a/Rollbar/PayloadQueue.cs
+++ b/Rollbar/PayloadQueue.cs
@@ -194,11 +194,17 @@ namespace Rollbar
         /// <summary>
         /// Flushes this instance.
         /// </summary>
-        public void Flush()
+        /// <returns>IEnumerable&lt;PayloadBundle&gt; flushed payload bundles.</returns>
+        public IEnumerable<PayloadBundle> Flush()
         {
             lock (this._syncLock)
             {
+                IEnumerable<PayloadBundle> flushedBundles = 
+                    new List<PayloadBundle>(this._queue.ToArray());
+
                 this._queue.Clear();
+
+                return flushedBundles;
             }
         }
     }

--- a/Rollbar/PayloadQueue.cs
+++ b/Rollbar/PayloadQueue.cs
@@ -76,7 +76,7 @@ namespace Rollbar
         /// Gets or sets the next dequeue time.
         /// </summary>
         /// <value>The next dequeue time.</value>
-        public DateTimeOffset NextDequeueTime { get; internal set; }
+        public DateTimeOffset NextDequeueTime { get; internal set; } = DateTimeOffset.Now;
 
         /// <summary>
         /// Gets the logger.
@@ -169,9 +169,9 @@ namespace Rollbar
                 {
                     result = this._queue.Dequeue();
 
-                    TimeSpan delta = TimeSpan.FromTicks(
-                        TimeSpan.FromMinutes(1).Ticks / this.Logger.Config.MaxReportsPerMinute
-                        );
+                    TimeSpan delta = this.Logger.Config.MaxReportsPerMinute.HasValue ? 
+                        TimeSpan.FromTicks(TimeSpan.FromMinutes(1).Ticks / this.Logger.Config.MaxReportsPerMinute.Value)
+                        : TimeSpan.Zero;
                     this.NextDequeueTime = DateTimeOffset.Now.Add(delta);
                 }
 

--- a/Rollbar/RollbarClient.cs
+++ b/Rollbar/RollbarClient.cs
@@ -185,8 +185,12 @@ namespace Rollbar
             RollbarResponse response = null;
             if (postResponse.IsSuccessStatusCode)
             {
-                string reply = await postResponse.Content.ReadAsStringAsync();
-                response = JsonConvert.DeserializeObject<RollbarResponse>(reply);
+                string reply = 
+                    await postResponse.Content.ReadAsStringAsync();
+                response = 
+                    JsonConvert.DeserializeObject<RollbarResponse>(reply);
+                response.RollbarRateLimit = 
+                    new RollbarRateLimit(postResponse.Headers);
                 response.HttpDetails =
                     $"Response: {postResponse}"
                     + Environment.NewLine

--- a/Rollbar/RollbarConfig.cs
+++ b/Rollbar/RollbarConfig.cs
@@ -72,7 +72,7 @@
             // let's set some default values:
             this.Environment = "production";
             this.Enabled = true;
-            this.MaxReportsPerMinute = 5000;
+            this.MaxReportsPerMinute = null; //5000;
             this.ReportingQueueDepth = 20;
             this.MaxItems = 0;
             this.CaptureUncaughtExceptions = true;
@@ -124,7 +124,6 @@
                 // reset the queue to use the new RollbarClient:
                 this.Logger.Queue.Flush();
                 this.Logger.Queue.UpdateClient(rollbarClient);
-                this.Logger.Queue.NextDequeueTime = DateTimeOffset.Now;
             }
 
             return this;
@@ -256,7 +255,7 @@
         /// <value>
         /// The maximum reports per minute.
         /// </value>
-        public int MaxReportsPerMinute { get; set; }
+        public int? MaxReportsPerMinute { get; set; }
 
         /// <summary>
         /// Gets or sets the reporting queue depth.

--- a/Rollbar/RollbarEventArgs.cs
+++ b/Rollbar/RollbarEventArgs.cs
@@ -16,6 +16,8 @@
     {
         private readonly RollbarLogger _logger;
 
+        private readonly DateTimeOffset _eventTimeStamp = DateTimeOffset.Now;
+
         internal RollbarLogger Logger
         {
             get { return this._logger; }
@@ -35,6 +37,9 @@
             )
         {
             this._logger = logger;
+
+            this.Payload = string.Empty;
+
             if (dataObject != null)
             {
                 try
@@ -65,6 +70,15 @@
         public string Payload { get; private set; }
 
         /// <summary>
+        /// Gets the event timestamp.
+        /// </summary>
+        /// <value>The event timestamp.</value>
+        public DateTimeOffset EventTimestamp
+        {
+            get { return this._eventTimeStamp; }
+        }
+
+        /// <summary>
         /// Traces as string.
         /// </summary>
         /// <returns>System.String.</returns>
@@ -83,7 +97,7 @@
         public virtual string TraceAsString(string indent)
         {
             StringBuilder sb = new StringBuilder();
-            sb.AppendLine(indent + this.GetType().Name + ":");
+            sb.AppendLine(indent + this._eventTimeStamp + " - " + this.GetType().Name + ":");
             sb.Append(indent + this.Config?.TraceAsString("  "));
             sb.AppendLine(indent + "  Payload: " + this.Payload);
             return sb.ToString();

--- a/Rollbar/RollbarLogger.cs
+++ b/Rollbar/RollbarLogger.cs
@@ -581,12 +581,14 @@ namespace Rollbar
             PayloadBundle payloadBundle = null;
 
             IRollbarPackage rollbarPackage = dataObject as IRollbarPackage;
+
             if (rollbarPackage != null)
             {
                 if (rollbarPackage.MustApplySynchronously)
                 {
                     rollbarPackage.PackageAsRollbarData();
                 }
+
                 payloadBundle =
                     new PayloadBundle(this, rollbarPackage, level, custom, timeoutAt, signal);
             }

--- a/Rollbar/RollbarQueueController.cs
+++ b/Rollbar/RollbarQueueController.cs
@@ -324,6 +324,10 @@ namespace Rollbar
                     case (int)RollbarApiErrorEventArgs.RollbarError.TooManyRequests:
                         ObeyPayloadTimeout(payloadBundle, queue);
                         tokenMetadata.IncrementTokenUsageDelay();
+                        if (tokenMetadata.TokenUsageDelay > response.RollbarRateLimit.WindowRemainingTimeSpan)
+                        {
+                            tokenMetadata.ResetTokenUsageDelay();
+                        }
                         this.OnRollbarEvent(
                             new RollbarApiErrorEventArgs(queue.Logger, payloadBundle.GetPayload(), response)
                             );

--- a/Rollbar/RollbarRateLimit.cs
+++ b/Rollbar/RollbarRateLimit.cs
@@ -56,7 +56,7 @@
         /// <summary>
         /// The window remaining time span
         /// </summary>
-        internal readonly TimeSpan WindowRemainingTimeSpan = 
+        public readonly TimeSpan WindowRemainingTimeSpan = 
             RollbarRateLimit.defaultClientSuspendTimeSpan;
 
         /// <summary>

--- a/Rollbar/RollbarRateLimit.cs
+++ b/Rollbar/RollbarRateLimit.cs
@@ -56,8 +56,7 @@
         /// <summary>
         /// The window remaining time span
         /// </summary>
-        public readonly TimeSpan WindowRemainingTimeSpan = 
-            RollbarRateLimit.defaultClientSuspendTimeSpan;
+        public readonly TimeSpan WindowRemainingTimeSpan = TimeSpan.Zero;
 
         /// <summary>
         /// The window remaining count until the limit is reached

--- a/Rollbar/RollbarRateLimit.cs
+++ b/Rollbar/RollbarRateLimit.cs
@@ -1,0 +1,143 @@
+﻿namespace Rollbar
+{
+    using Rollbar.Common;
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http.Headers;
+    using System.Text;
+
+    /// <summary>
+    /// Class RollbarRateLimit.
+    /// </summary>
+    public class RollbarRateLimit
+    {
+        private static readonly TimeSpan defaultClientSuspendTimeSpan = TimeSpan.FromMinutes(1);
+
+        private const int defaultPayloadsPerWindow = 5000;
+
+        private readonly DateTimeOffset _timeStamp = DateTimeOffset.Now;
+
+        /// <summary>
+        /// Class RollbarTateLimitHeaders.
+        /// </summary>
+        internal static class RollbarRateLimitHeaders
+        {
+            /// <summary>
+            /// The limit
+            /// </summary>
+            public const string Limit = "x-rate-limit-limit";
+            /// <summary>
+            /// The remaining count until the limit is reached
+            /// </summary>
+            public const string Remaining = "x-rate-limit-remaining";
+            /// <summary>
+            /// The reset time for the current limit window
+            /// </summary>
+            public const string Reset = "x-rate-limit-reset";
+
+            /// <summary>
+            /// The remaining seconds of the current limit window
+            /// </summary>
+            public const string RemainingSeconds = "x-rate-limit-remaining-seconds";
+        }
+
+        /// <summary>
+        /// The window limit
+        /// </summary>
+        internal readonly int WindowLimit = 
+            RollbarRateLimit.defaultPayloadsPerWindow;
+        
+        /// <summary>
+        /// The current limit window end time
+        /// </summary>
+        internal readonly DateTimeOffset WindowEnd = 
+            DateTimeOffset.Now.Add(RollbarRateLimit.defaultClientSuspendTimeSpan);
+
+        /// <summary>
+        /// The window remaining time span
+        /// </summary>
+        internal readonly TimeSpan WindowRemainingTimeSpan = 
+            RollbarRateLimit.defaultClientSuspendTimeSpan;
+
+        /// <summary>
+        /// The window remaining count until the limit is reached
+        /// </summary>
+        public readonly int WindowRemaining =
+            RollbarRateLimit.defaultPayloadsPerWindow;
+
+        /// <summary>
+        /// Gets the client suspension time span.
+        /// </summary>
+        /// <value>The client suspension time span.</value>
+        public TimeSpan ClientSuspensionTimeSpan { get; private set; }
+
+        /// <summary>
+        /// Gets the client suspension end.
+        /// </summary>
+        /// <value>The client suspension end.</value>
+        public DateTimeOffset ClientSuspensionEnd { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RollbarRateLimit"/> class.
+        /// </summary>
+        /// <param name="httpResponseHeaders">The HTTP response headers.</param>
+        public RollbarRateLimit(HttpResponseHeaders httpResponseHeaders)
+            : this(httpResponseHeaders as HttpHeaders)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RollbarRateLimit"/> class.
+        /// </summary>
+        /// <param name="httpHeaders">The HTTP headers.</param>
+        internal RollbarRateLimit(HttpHeaders httpHeaders)
+        {
+            // Here we are relying on the preset initial/default values
+            // of the rate limiting parameters in case any header we are
+            // looking for is missing:
+
+            this.WindowLimit =
+                httpHeaders.ParseHeaderValueSafelyOrDefault<int>(
+                    RollbarRateLimitHeaders.Limit, 
+                    int.TryParse, 
+                    this.WindowLimit
+                    );
+            this.WindowRemaining =
+                httpHeaders.ParseHeaderValueSafelyOrDefault<int>(
+                    RollbarRateLimitHeaders.Remaining, 
+                    int.TryParse, 
+                    this.WindowRemaining
+                    );
+            this.WindowEnd =
+                httpHeaders.ParseHeaderValueSafelyOrDefault<DateTimeOffset>(
+                    RollbarRateLimitHeaders.Reset, 
+                    DateTimeUtil.TryParseFromUnixTimestampInSecondsString, 
+                    this.WindowEnd
+                    );
+            int windowRemainigSeconds = Convert.ToInt32(this.WindowRemainingTimeSpan.TotalSeconds);
+            windowRemainigSeconds = 
+                httpHeaders.ParseHeaderValueSafelyOrDefault<int>(
+                    RollbarRateLimitHeaders.RemainingSeconds,
+                    int.TryParse,
+                    windowRemainigSeconds
+                    );
+            this.WindowRemainingTimeSpan = TimeSpan.FromSeconds(windowRemainigSeconds);
+
+            // Now, let's perform calculations of rate limiting factors needed by a Rollbar notifier:
+
+            this.ClientSuspensionTimeSpan = 
+                RollbarRateLimit.defaultClientSuspendTimeSpan < this.WindowRemainingTimeSpan 
+                ? RollbarRateLimit.defaultClientSuspendTimeSpan 
+                : this.WindowRemainingTimeSpan;
+
+            this.ClientSuspensionEnd = this._timeStamp.Add(this.ClientSuspensionTimeSpan);
+        }
+
+        /// <summary>
+        /// Prevents a default instance of the <see cref="RollbarRateLimit"/> class from being created.
+        /// </summary>
+        private RollbarRateLimit()
+        {
+        }
+    }
+}

--- a/Rollbar/RollbarResponse.cs
+++ b/Rollbar/RollbarResponse.cs
@@ -37,6 +37,13 @@
         public string HttpDetails { get; set; }
 
         /// <summary>
+        /// Gets or sets the rollbar rate limit.
+        /// </summary>
+        /// <value>The rollbar rate limit.</value>
+        [JsonIgnore]
+        public RollbarRateLimit RollbarRateLimit { get; set; }
+
+        /// <summary>
         /// Traces as string.
         /// </summary>
         /// <returns>System.String.</returns>

--- a/Rollbar/_Rollbar.cd
+++ b/Rollbar/_Rollbar.cd
@@ -51,7 +51,7 @@
     <Lollipop Position="0.2" />
   </Class>
   <Class Name="Rollbar.RollbarApiErrorEventArgs">
-    <Position X="13" Y="9.25" Width="6.5" />
+    <Position X="26.75" Y="7.5" Width="6.5" />
     <Compartments>
       <Compartment Name="Nested Types" Collapsed="false" />
     </Compartments>
@@ -73,29 +73,29 @@
     </TypeIdentifier>
   </Class>
   <Class Name="Rollbar.RollbarEventArgs">
-    <Position X="13" Y="0.75" Width="6.5" />
+    <Position X="18.75" Y="0.75" Width="6.5" />
     <TypeIdentifier>
-      <HashCode>AAAAAAAAAgIAAAAAAAAQAAAAIAAAAAAQAAAAAAAAAAA=</HashCode>
+      <HashCode>AAAAAAAAAgIAAAAAAAAQAAAAIAAAAAAQAAAQgAAAAAA=</HashCode>
       <FileName>RollbarEventArgs.cs</FileName>
     </TypeIdentifier>
     <Lollipop Position="0.2" />
   </Class>
   <Class Name="Rollbar.CommunicationEventArgs">
-    <Position X="13" Y="7" Width="6.5" />
+    <Position X="26.75" Y="5" Width="6.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAABAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAA=</HashCode>
       <FileName>CommunicationEventArgs.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Rollbar.CommunicationErrorEventArgs">
-    <Position X="13" Y="4.5" Width="6.5" />
+    <Position X="13" Y="5" Width="6.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAQAAAAAACAAAAAAAAAAQAAAAAAAAAAA=</HashCode>
       <FileName>CommunicationErrorEventArgs.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Rollbar.RollbarAssistant">
-    <Position X="13" Y="17.25" Width="7.5" />
+    <Position X="15" Y="10" Width="7.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
       <FileName>RollbarAssistant.cs</FileName>
@@ -112,10 +112,27 @@
   <Class Name="Rollbar.RollbarPackageDecoratorBase">
     <Position X="0.5" Y="22.5" Width="6.25" />
     <TypeIdentifier>
-      <HashCode>AAAABAAAAAAAAAAAAgAAAAAAAAAAAAAAgAAAQAAwAAA=</HashCode>
+      <HashCode>AAAABAAAAAAAAAAAAgAAAAAAAAAAAAAAgAAAQACwAAA=</HashCode>
       <FileName>RollbarPackageDecoratorBase.cs</FileName>
     </TypeIdentifier>
     <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="Rollbar.PayloadDropEventArgs">
+    <Position X="19.75" Y="5" Width="6.5" />
+    <Compartments>
+      <Compartment Name="Nested Types" Collapsed="false" />
+    </Compartments>
+    <NestedTypes>
+      <Enum Name="Rollbar.PayloadDropEventArgs.DropReason">
+        <TypeIdentifier>
+          <NewMemberFileName>PayloadDropEventArgs.cs</NewMemberFileName>
+        </TypeIdentifier>
+      </Enum>
+    </NestedTypes>
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAQAAAAAAAAAAA=</HashCode>
+      <FileName>PayloadDropEventArgs.cs</FileName>
+    </TypeIdentifier>
   </Class>
   <Interface Name="Rollbar.IRollbar">
     <Position X="0.5" Y="12.75" Width="5.5" />

--- a/SdkCommon.csproj
+++ b/SdkCommon.csproj
@@ -9,9 +9,32 @@
 
   <SdkVersion>3.1.0</SdkVersion>
     <PackageReleaseNotes>
-      - resolve #381: Correct unit tests that are failing on the CI server. 
-      - resolve #368: Make SDK to obey service-side enforced rate limits unless client-side RollbarConfig defines one
+      - test: resolve #381: Correct unit tests that are failing on the CI server. 
+      - feat: resolve #368: Make SDK to obey service-side enforced rate limits unless client-side RollbarConfig defines one
     </PackageReleaseNotes>
+    
+    <!--
+    Release Notes Tagging Conventions:
+    ==================================
+    1.  Every entry within the PackageReleaseNotes element is expected to be started with
+        at least one of the tags listed:
+        
+        feat:     A new feature
+        fix:      A bug fix
+        docs:     Documentation only changes
+        style:    Changes that do not affect the meaning of the code
+        refactor: A code change that neither a bug fix nor a new feature
+        perf:     A code change that improves performance
+        test:     Adding or modifying unit test code
+        chore:    Changes to the build process or auxiliary tools and libraries such as documentation generation, etc.
+    
+    2.  Every entry within the PackageReleaseNotes element is expected to be tagged with 
+        EITHER 
+        "resolve #GITHUB_ISSUE_NUMBER:" - meaning completely addresses the GitHub issue
+        OR 
+        "ref #GITHUB_ISSUE_NUMBER:" - meaning relevant to the GitHub issue
+        depending on what is more appropriate in each case.
+    -->
     
     <Version>$(SdkVersion)</Version>
     <AssemblyVersion>$(SdkVersion)</AssemblyVersion>

--- a/SdkCommon.csproj
+++ b/SdkCommon.csproj
@@ -11,6 +11,7 @@
     <PackageReleaseNotes>
       - test: resolve #381: Correct unit tests that are failing on the CI server. 
       - feat: resolve #368: Make SDK to obey service-side enforced rate limits unless client-side RollbarConfig defines one
+      - feat: resolve #384: Make sure relevant queues are flushed on rate-limit suspension
     </PackageReleaseNotes>
     
     <!--

--- a/SdkCommon.csproj
+++ b/SdkCommon.csproj
@@ -7,9 +7,10 @@
   
   <PropertyGroup Label="SDK Common NuGet Packaging Info" >
 
-    <SdkVersion>3.0.7</SdkVersion>
+  <SdkVersion>3.1.0</SdkVersion>
     <PackageReleaseNotes>
       - resolve #381: Correct unit tests that are failing on the CI server. 
+      - resolve #368: Make SDK to obey service-side enforced rate limits unless client-side RollbarConfig defines one
     </PackageReleaseNotes>
     
     <Version>$(SdkVersion)</Version>

--- a/UnitTest.Rollbar/AccessTokenQueuesMetadataFixture.cs
+++ b/UnitTest.Rollbar/AccessTokenQueuesMetadataFixture.cs
@@ -1,26 +1,36 @@
-﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-
-namespace UnitTest.Rollbar
+﻿namespace UnitTest.Rollbar
 {
     using global::Rollbar;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System;
 
+    /// <summary>
+    /// Defines test class AccessTokenQueuesMetadataFixture.
+    /// </summary>
     [TestClass]
     [TestCategory(nameof(AccessTokenQueuesMetadataFixture))]
     public class AccessTokenQueuesMetadataFixture
     {
+        /// <summary>
+        /// Setups the fixture.
+        /// </summary>
         [TestInitialize]
         public void SetupFixture()
         {
         }
 
+        /// <summary>
+        /// Tears down fixture.
+        /// </summary>
         [TestCleanup]
         public void TearDownFixture()
         {
 
         }
 
+        /// <summary>
+        /// Defines the test method ConstructionTest.
+        /// </summary>
         [TestMethod]
         public void ConstructionTest()
         {
@@ -28,43 +38,49 @@ namespace UnitTest.Rollbar
 
             Assert.AreEqual(RollbarUnitTestSettings.AccessToken, metadata.AccessToken);
             Assert.IsNotNull(metadata.Queues);
-            Assert.IsFalse(metadata.NextTimeTokenUsage.HasValue);
+            Assert.IsTrue(metadata.NextTimeTokenUsage < DateTimeOffset.Now);
             Assert.AreEqual(TimeSpan.Zero, metadata.TokenUsageDelay);
         }
 
+        /// <summary>
+        /// Defines the test method DelayIncrementTest.
+        /// </summary>
         [TestMethod]
         public void DelayIncrementTest()
         {
             var metadata = new AccessTokenQueuesMetadata(RollbarUnitTestSettings.AccessToken);
 
-            Assert.IsFalse(metadata.NextTimeTokenUsage.HasValue);
+            Assert.IsTrue(metadata.NextTimeTokenUsage < DateTimeOffset.Now);
             Assert.AreEqual(TimeSpan.Zero, metadata.TokenUsageDelay);
 
             metadata.IncrementTokenUsageDelay();
-            Assert.IsTrue(metadata.NextTimeTokenUsage.HasValue);
+            Assert.IsTrue(metadata.NextTimeTokenUsage > DateTimeOffset.Now);
             Assert.IsTrue(TimeSpan.Zero < metadata.TokenUsageDelay);
 
-            var nextTimeUsage = metadata.NextTimeTokenUsage.Value;
+            var nextTimeUsage = metadata.NextTimeTokenUsage;
             var usageDelay = metadata.TokenUsageDelay;
             metadata.IncrementTokenUsageDelay();
-            Assert.IsTrue(metadata.NextTimeTokenUsage.Value > nextTimeUsage);
+            Assert.IsTrue(metadata.NextTimeTokenUsage > nextTimeUsage);
             Assert.IsTrue(usageDelay < metadata.TokenUsageDelay);
         }
 
+        /// <summary>
+        /// Defines the test method DelayResetTest.
+        /// </summary>
         [TestMethod]
         public void DelayResetTest()
         {
             var metadata = new AccessTokenQueuesMetadata(RollbarUnitTestSettings.AccessToken);
 
-            Assert.IsFalse(metadata.NextTimeTokenUsage.HasValue);
+            Assert.IsTrue(metadata.NextTimeTokenUsage < DateTimeOffset.Now);
             Assert.AreEqual(TimeSpan.Zero, metadata.TokenUsageDelay);
 
             metadata.IncrementTokenUsageDelay();
-            Assert.IsTrue(metadata.NextTimeTokenUsage.HasValue);
+            Assert.IsTrue(metadata.NextTimeTokenUsage > DateTimeOffset.Now);
             Assert.IsTrue(TimeSpan.Zero < metadata.TokenUsageDelay);
 
             metadata.ResetTokenUsageDelay();
-            Assert.IsFalse(metadata.NextTimeTokenUsage.HasValue);
+            //Assert.IsTrue(metadata.NextTimeTokenUsage <= DateTimeOffset.Now);
             Assert.AreEqual(TimeSpan.Zero, metadata.TokenUsageDelay);
         }
     }

--- a/UnitTest.Rollbar/AccessTokenQueuesMetadataFixture.cs
+++ b/UnitTest.Rollbar/AccessTokenQueuesMetadataFixture.cs
@@ -39,49 +39,7 @@
             Assert.AreEqual(RollbarUnitTestSettings.AccessToken, metadata.AccessToken);
             Assert.IsNotNull(metadata.Queues);
             Assert.IsTrue(metadata.NextTimeTokenUsage < DateTimeOffset.Now);
-            Assert.AreEqual(TimeSpan.Zero, metadata.TokenUsageDelay);
         }
 
-        /// <summary>
-        /// Defines the test method DelayIncrementTest.
-        /// </summary>
-        [TestMethod]
-        public void DelayIncrementTest()
-        {
-            var metadata = new AccessTokenQueuesMetadata(RollbarUnitTestSettings.AccessToken);
-
-            Assert.IsTrue(metadata.NextTimeTokenUsage < DateTimeOffset.Now);
-            Assert.AreEqual(TimeSpan.Zero, metadata.TokenUsageDelay);
-
-            metadata.IncrementTokenUsageDelay();
-            Assert.IsTrue(metadata.NextTimeTokenUsage > DateTimeOffset.Now);
-            Assert.IsTrue(TimeSpan.Zero < metadata.TokenUsageDelay);
-
-            var nextTimeUsage = metadata.NextTimeTokenUsage;
-            var usageDelay = metadata.TokenUsageDelay;
-            metadata.IncrementTokenUsageDelay();
-            Assert.IsTrue(metadata.NextTimeTokenUsage > nextTimeUsage);
-            Assert.IsTrue(usageDelay < metadata.TokenUsageDelay);
-        }
-
-        /// <summary>
-        /// Defines the test method DelayResetTest.
-        /// </summary>
-        [TestMethod]
-        public void DelayResetTest()
-        {
-            var metadata = new AccessTokenQueuesMetadata(RollbarUnitTestSettings.AccessToken);
-
-            Assert.IsTrue(metadata.NextTimeTokenUsage < DateTimeOffset.Now);
-            Assert.AreEqual(TimeSpan.Zero, metadata.TokenUsageDelay);
-
-            metadata.IncrementTokenUsageDelay();
-            Assert.IsTrue(metadata.NextTimeTokenUsage > DateTimeOffset.Now);
-            Assert.IsTrue(TimeSpan.Zero < metadata.TokenUsageDelay);
-
-            metadata.ResetTokenUsageDelay();
-            //Assert.IsTrue(metadata.NextTimeTokenUsage <= DateTimeOffset.Now);
-            Assert.AreEqual(TimeSpan.Zero, metadata.TokenUsageDelay);
-        }
     }
 }

--- a/UnitTest.Rollbar/Common/HttpHeadersExtensionFixture.cs
+++ b/UnitTest.Rollbar/Common/HttpHeadersExtensionFixture.cs
@@ -1,0 +1,213 @@
+﻿namespace UnitTest.Rollbar.Common
+{
+    using global::Rollbar;
+    using global::Rollbar.Common;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
+    using System.Diagnostics;
+    using System.Text;
+    using System.Net.Http.Headers;
+    using Moq;
+    using System.Linq;
+
+    /// <summary>
+    /// Defines test class HttpHeadersExtensionFixture.
+    /// </summary>
+    [TestClass]
+    [TestCategory(nameof(HttpHeadersExtensionFixture))]
+    public class HttpHeadersExtensionFixture
+    {
+        /// <summary>
+        /// Setups the fixture.
+        /// </summary>
+        [TestInitialize]
+        public void SetupFixture()
+        {
+        }
+
+        /// <summary>
+        /// Tears down fixture.
+        /// </summary>
+        [TestCleanup]
+        public void TearDownFixture()
+        {
+        }
+
+        /// <summary>
+        /// Defines the test method TestEncodingBytesCountCalculation.
+        /// </summary>
+        [TestMethod]
+        public void TestGetHeaderValuesSafely()
+        {
+            var headersMock = new Mock<HttpHeaders>();
+            HttpHeaders headers = headersMock.Object;
+
+            // empty headers test:
+            var result = headers.GetHeaderValuesSafely("DoesNotMatter");
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Count());
+
+            // valid header test:
+            var headerName = "HeaderName";
+            var headerValue = "HeaderValue";
+            headers.Add(headerName, headerValue);
+            result = headers.GetHeaderValuesSafely(headerName);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.Count());
+
+            // valid header test:
+            headerName = "MultiValueHeader";
+            var headerValue1 = "HeaderValue1";
+            var headerValue2 = "HeaderValue2";
+            headers.Add(headerName, new string[] { headerValue1, headerValue2, });
+            result = headers.GetHeaderValuesSafely(headerName);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Count());
+            Assert.AreEqual(headerValue1, result.FirstOrDefault());
+            Assert.AreEqual(headerValue2, result.LastOrDefault());
+
+            // invalid header test:
+            result = headers.GetHeaderValuesSafely("WRONG");
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0, result.Count());
+        }
+
+        /// <summary>
+        /// Defines the test method TestGetLastHeaderValueSafely.
+        /// </summary>
+        [TestMethod]
+        public void TestGetLastHeaderValueSafely()
+        {
+            var headersMock = new Mock<HttpHeaders>();
+            HttpHeaders headers = headersMock.Object;
+
+            // empty headers test:
+            var result = headers.GetLastHeaderValueSafely("DoesNotMatter");
+            Assert.IsNull(result);
+
+            // valid header test:
+            var headerName = "HeaderName";
+            var headerValue = "HeaderValue";
+            headers.Add(headerName, headerValue);
+            result = headers.GetLastHeaderValueSafely(headerName);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(headerValue, result);
+
+            // valid header test:
+            headerName = "MultiValueHeader";
+            var headerValue1 = "HeaderValue1";
+            var headerValue2 = "HeaderValue2";
+            headers.Add(headerName, new string[] {headerValue1, headerValue2, });
+            result = headers.GetLastHeaderValueSafely(headerName);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(headerValue2, result);
+
+            // invalid header test:
+            result = headers.GetLastHeaderValueSafely("WRONG");
+            Assert.IsNull(result);
+        }
+
+        /// <summary>
+        /// Defines the test method TestParseHeaderValueSafelyIfAny.
+        /// </summary>
+        [TestMethod]
+        public void TestParseHeaderValueSafelyIfAny()
+        {
+            var headersMock = new Mock<HttpHeaders>();
+            HttpHeaders headers = headersMock.Object;
+
+            // empty headers test:
+            var result = headers.ParseHeaderValueSafelyIfAny<int>("DoesNotMatter", int.TryParse);
+            Assert.IsNull(result);
+            Assert.IsFalse(result.HasValue);
+
+            // valid header test:
+            var headerName = "HeaderName";
+            var headerValue = 123;
+            headers.Add(headerName, headerValue.ToString());
+            result = headers.ParseHeaderValueSafelyIfAny<int>(headerName, int.TryParse);
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(headerValue, result.Value);
+
+            // valid header test:
+            headerName = "MultiValueHeader";
+            var headerValue1 = 123;
+            var headerValue2 = 321;
+            headers.Add(headerName, new string[] { headerValue1.ToString(), headerValue2.ToString(), });
+            result = headers.ParseHeaderValueSafelyIfAny<int>(headerName, int.TryParse);
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(headerValue2, result.Value);
+
+            // invalid header test:
+            result = headers.ParseHeaderValueSafelyIfAny<int>("WRONG", int.TryParse);
+            Assert.IsNull(result);
+            Assert.IsFalse(result.HasValue);
+        }
+
+        /// <summary>
+        /// Defines the test method TestParseHeaderValueSafelyOrDefault.
+        /// </summary>
+        [TestMethod]
+        public void TestParseHeaderValueSafelyOrDefault()
+        {
+            var defaultValue = int.MaxValue;
+            var headersMock = new Mock<HttpHeaders>();
+            HttpHeaders headers = headersMock.Object;
+
+            // empty headers test:
+            var result = headers.ParseHeaderValueSafelyOrDefault<int>("DoesNotMatter", int.TryParse, defaultValue);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(defaultValue, result);
+
+            // valid header test:
+            var headerName = "HeaderName";
+            var headerValue = 123;
+            headers.Add(headerName, headerValue.ToString());
+            result = headers.ParseHeaderValueSafelyOrDefault<int>(headerName, int.TryParse, defaultValue);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(headerValue, result);
+
+            // valid header test:
+            headerName = "MultiValueHeader";
+            var headerValue1 = 123;
+            var headerValue2 = 321;
+            headers.Add(headerName, new string[] { headerValue1.ToString(), headerValue2.ToString(), });
+            result = headers.ParseHeaderValueSafelyOrDefault<int>(headerName, int.TryParse, defaultValue);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(headerValue2, result);
+
+            // invalid header test:
+            result = headers.ParseHeaderValueSafelyOrDefault<int>("WRONG", int.TryParse, defaultValue);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(defaultValue, result);
+        }
+
+        /// <summary>
+        /// Defines the test method TestParseRateLimitResetHeader.
+        /// </summary>
+        [TestMethod]
+        public void TestParseRateLimitResetHeader()
+        {
+            //X-Rate-Limit-Reset: 1554828920
+
+            var defaultValue = DateTimeOffset.MaxValue;
+            var headersMock = new Mock<HttpHeaders>();
+            HttpHeaders headers = headersMock.Object;
+
+            // empty headers test:
+            var result = headers.ParseHeaderValueSafelyOrDefault<DateTimeOffset>("DoesNotMatter", DateTimeUtil.TryParseFromUnixTimestampInSecondsString, defaultValue);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(defaultValue, result);
+
+            // valid header test:
+            var headerName = "X-Rate-Limit-Reset";
+            var headerValue = "1554828920";
+            headers.Add(headerName, headerValue.ToString());
+            result = headers.ParseHeaderValueSafelyOrDefault<DateTimeOffset>(headerName, DateTimeUtil.TryParseFromUnixTimestampInSecondsString, defaultValue);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(DateTimeUtil.ConvertFromUnixTimestampInSeconds(long.Parse(headerValue)), result);
+        }
+    }
+}

--- a/UnitTest.Rollbar/Common/StringUtilityFixture.cs
+++ b/UnitTest.Rollbar/Common/StringUtilityFixture.cs
@@ -1,30 +1,38 @@
-﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-
-namespace UnitTest.Rollbar.Common
+﻿namespace UnitTest.Rollbar.Common
 {
     using global::Rollbar;
     using global::Rollbar.Common;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System;
     using System.Diagnostics;
-    using System.Linq;
     using System.Text;
-    using System.Threading;
 
+    /// <summary>
+    /// Defines test class StringUtilityFixture.
+    /// </summary>
     [TestClass]
     [TestCategory(nameof(StringUtilityFixture))]
     public class StringUtilityFixture
     {
+        /// <summary>
+        /// Setups the fixture.
+        /// </summary>
         [TestInitialize]
         public void SetupFixture()
         {
         }
 
+        /// <summary>
+        /// Tears down fixture.
+        /// </summary>
         [TestCleanup]
         public void TearDownFixture()
         {
         }
 
+        /// <summary>
+        /// Defines the test method TestEncodingBytesCountCalculation.
+        /// </summary>
         [TestMethod]
         public void TestEncodingBytesCountCalculation()
         {
@@ -55,6 +63,9 @@ namespace UnitTest.Rollbar.Common
             }
         }
 
+        /// <summary>
+        /// Defines the test method TestTruncation.
+        /// </summary>
         [TestMethod]
         public void TestTruncation()
         {
@@ -78,5 +89,66 @@ namespace UnitTest.Rollbar.Common
             }
         }
 
+        /// <summary>
+        /// Defines the test method TestIntParsing.
+        /// </summary>
+        [TestMethod]
+        public void TestIntParsing()
+        {
+            Assert.IsFalse(StringUtility.Parse<int>("WRONG", int.TryParse).HasValue);
+
+            Assert.IsTrue(StringUtility.Parse<int>("123", int.TryParse).HasValue);
+            Assert.IsTrue(StringUtility.Parse<int>("-123", int.TryParse).HasValue);
+
+            Assert.AreEqual(123, StringUtility.Parse<int>("123", int.TryParse).Value);
+            Assert.AreEqual(-123, StringUtility.Parse<int>("-123", int.TryParse).Value);
+        }
+
+        /// <summary>
+        /// Defines the test method TestIntParsingWithDefault.
+        /// </summary>
+        [TestMethod]
+        public void TestIntParsingWithDefault()
+        {
+            const int defaultValue = int.MaxValue;
+            Assert.AreEqual(defaultValue, StringUtility.ParseOrDefault<int>("WRONG", int.TryParse, defaultValue));
+
+            Assert.AreEqual(123, StringUtility.ParseOrDefault<int>("123", int.TryParse, defaultValue));
+            Assert.AreEqual(-123, StringUtility.ParseOrDefault<int>("-123", int.TryParse, defaultValue));
+        }
+
+        /// <summary>
+        /// Defines the test method TestDateTimeOffsetParsing.
+        /// </summary>
+        [TestMethod]
+        public void TestDateTimeOffsetParsing()
+        {
+            Assert.IsFalse(StringUtility.Parse<DateTimeOffset>("WRONG", DateTimeOffset.TryParse).HasValue);
+
+            DateTimeOffset testDate = DateTimeOffset.Now;
+            testDate = new DateTimeOffset(
+                testDate.Date.Year, testDate.Date.Month, testDate.Date.Day, 
+                testDate.DateTime.Hour, testDate.DateTime.Minute, testDate.DateTime.Second, 
+                testDate.Offset);
+            Assert.IsTrue(StringUtility.Parse<DateTimeOffset>(testDate.ToString(), DateTimeOffset.TryParse).HasValue);
+            Assert.AreEqual(testDate, StringUtility.Parse<DateTimeOffset>(testDate.ToString(), DateTimeOffset.TryParse).Value);
+        }
+
+        /// <summary>
+        /// Defines the test method TestDateTimeOffsetParsingWithDefault.
+        /// </summary>
+        [TestMethod]
+        public void TestDateTimeOffsetParsingWithDefault()
+        {
+            DateTimeOffset defaultValue = DateTimeOffset.MaxValue;
+            Assert.AreEqual(defaultValue, StringUtility.ParseOrDefault<DateTimeOffset>("WRONG", DateTimeOffset.TryParse, defaultValue));
+
+            DateTimeOffset testDate = DateTimeOffset.Now;
+            testDate = new DateTimeOffset(
+                testDate.Date.Year, testDate.Date.Month, testDate.Date.Day,
+                testDate.DateTime.Hour, testDate.DateTime.Minute, testDate.DateTime.Second,
+                testDate.Offset);
+            Assert.AreEqual(testDate, StringUtility.ParseOrDefault<DateTimeOffset>(testDate.ToString(), DateTimeOffset.TryParse, defaultValue));
+        }
     }
 }

--- a/UnitTest.Rollbar/RollbarLiveFixtureBase.cs
+++ b/UnitTest.Rollbar/RollbarLiveFixtureBase.cs
@@ -32,7 +32,6 @@ namespace UnitTest.Rollbar
 
         protected static readonly TimeSpan defaultRollbarTimeout = TimeSpan.FromSeconds(3);
 
-
         protected RollbarLiveFixtureBase()
         {
             RollbarQueueController.Instance.InternalEvent += OnRollbarInternalEvent;
@@ -66,6 +65,29 @@ namespace UnitTest.Rollbar
 
         private void OnRollbarInternalEvent(object sender, RollbarEventArgs e)
         {
+            //// for basic RollbarRateLimitVerification test:
+            //switch (e)
+            //{
+            //    case RollbarApiErrorEventArgs apiErrorEvent:
+            //        //this.ApiErrorEvents.Add(apiErrorEvent);
+            //        return;
+            //    case CommunicationEventArgs commEvent:
+            //        Console.WriteLine(commEvent.EventTimestamp + " SENT: ");
+            //        return;
+            //    case CommunicationErrorEventArgs commErrorEvent:
+            //        //this.CommunicationErrorEvents.Add(commErrorEvent);
+            //        return;
+            //    case InternalErrorEventArgs internalErrorEvent:
+            //        //this.InternalSdkErrorEvents.Add(internalErrorEvent);
+            //        return;
+            //    case PayloadDropEventArgs payloadDropEvent:
+            //        Console.WriteLine(payloadDropEvent.EventTimestamp + " DROP: " + payloadDropEvent.Reason);
+            //        return;
+            //    default:
+            //        //Assert.Fail("Unexpected RollbarEventArgs specialization type!");
+            //        return;
+            //}
+
             Console.WriteLine(e.TraceAsString());
             Trace.WriteLine(e.TraceAsString());
 

--- a/UnitTest.Rollbar/RollbarLoggerFixture.cs
+++ b/UnitTest.Rollbar/RollbarLoggerFixture.cs
@@ -801,10 +801,10 @@ namespace UnitTest.Rollbar
             public const string ThreadLogID = "stress.thread.log.id";
         }
 
-#endregion Stress test
+        #endregion Stress test
 
         //[TestMethod]
-        //public void RollbarRateLimitVerification()
+        //public void _RollbarRateLimitVerification()
         //{
         //    RollbarConfig config = this.ProvideLiveRollbarConfig() as RollbarConfig;
 
@@ -814,7 +814,7 @@ namespace UnitTest.Rollbar
         //    {
         //        rollbar.Configure(config);
 
-        //        while(count++ < 300)
+        //        while (count++ < 300)
         //        {
         //            rollbar.Critical("RollbarRateLimitVerification test");
         //            Thread.Sleep(TimeSpan.FromSeconds(1));

--- a/UnitTest.Rollbar/RollbarLoggerFixture.cs
+++ b/UnitTest.Rollbar/RollbarLoggerFixture.cs
@@ -447,7 +447,7 @@ namespace UnitTest.Rollbar
                     this.ExpectedCommunicationEventsTotal++;
                     logger.AsBlockingLogger(defaultRollbarTimeout).Log(ErrorLevel.Error, "test message");
                 }
-                catch
+                catch(Exception ex)
                 {
                     Assert.Fail("should never reach here!");
                 }
@@ -802,6 +802,26 @@ namespace UnitTest.Rollbar
         }
 
 #endregion Stress test
+
+        //[TestMethod]
+        //public void RollbarRateLimitVerification()
+        //{
+        //    RollbarConfig config = this.ProvideLiveRollbarConfig() as RollbarConfig;
+
+        //    int count = 0;
+
+        //    using (IRollbar rollbar = this.ProvideDisposableRollbar())
+        //    {
+        //        rollbar.Configure(config);
+
+        //        while(count++ < 300)
+        //        {
+        //            rollbar.Critical("RollbarRateLimitVerification test");
+        //            Thread.Sleep(TimeSpan.FromSeconds(1));
+        //        }
+
+        //    }
+        //}
 
     }
 }

--- a/UnitTest.Rollbar/RollbarRateLimitFixture.cs
+++ b/UnitTest.Rollbar/RollbarRateLimitFixture.cs
@@ -1,0 +1,68 @@
+﻿namespace UnitTest.Rollbar
+{
+    using global::Rollbar;
+    using global::Rollbar.Common;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
+    using System.Diagnostics;
+    using System.Text;
+    using System.Net.Http.Headers;
+    using Moq;
+    using System.Linq;
+
+    /// <summary>
+    /// Defines test class RollbarRateLimitFixture.
+    /// </summary>
+    [TestClass]
+    [TestCategory(nameof(RollbarRateLimitFixture))]
+    public class RollbarRateLimitFixture
+    {
+        /// <summary>
+        /// Setups the fixture.
+        /// </summary>
+        [TestInitialize]
+        public void SetupFixture()
+        {
+        }
+
+        /// <summary>
+        /// Tears down fixture.
+        /// </summary>
+        [TestCleanup]
+        public void TearDownFixture()
+        {
+        }
+
+        /// <summary>
+        /// Defines the test method TestRollbarRateLimit.
+        /// </summary>
+        [TestMethod]
+        public void TestRollbarRateLimit()
+        {
+            var headersMock = new Mock<HttpHeaders>();
+            HttpHeaders headers = headersMock.Object;
+
+            var limitHeader = RollbarRateLimit.RollbarRateLimitHeaders.Limit;
+            var limitValue = 5000;
+            headers.Add(limitHeader, limitValue.ToString());
+
+            var remainingHeader = RollbarRateLimit.RollbarRateLimitHeaders.Remaining;
+            var remainingValue = 4992;
+            headers.Add(remainingHeader, remainingValue.ToString());
+
+            var resetHeader = RollbarRateLimit.RollbarRateLimitHeaders.Reset;
+            var resetValue = 1554828920;
+            headers.Add(resetHeader, resetValue.ToString());
+
+            var remainingSecondsHeader = RollbarRateLimit.RollbarRateLimitHeaders.RemainingSeconds;
+            var remainingSecondsValue = 60;
+            headers.Add(remainingSecondsHeader, remainingSecondsValue.ToString());
+
+            RollbarRateLimit rollbarRateLimit = new RollbarRateLimit(headers);
+            Assert.AreEqual(remainingValue, rollbarRateLimit.WindowRemaining);
+            Assert.AreEqual(limitValue, rollbarRateLimit.WindowLimit);
+            Assert.AreEqual(TimeSpan.FromSeconds(remainingSecondsValue), rollbarRateLimit.WindowRemainingTimeSpan);
+            Assert.AreEqual(DateTimeUtil.ConvertFromUnixTimestampInSeconds(resetValue), rollbarRateLimit.WindowEnd);
+        }
+    }
+}


### PR DESCRIPTION
- resolve #368: Make SDK to obey service-side enforced rate limits unless client-side RollbarConfig defines one