### PR TITLE
fix: ref#457

### DIFF
--- a/Rollbar/Common/ReflectionUtility.cs
+++ b/Rollbar/Common/ReflectionUtility.cs
@@ -153,5 +153,20 @@
             return types.ToArray();
         }
 
+        /// <summary>
+        /// Does the type implement interface.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <param name="interfaceType">Type of the interface.</param>
+        /// <returns><c>true</c> if implements, <c>false</c> otherwise.</returns>
+        public static bool DoesTypeImplementInterface(Type type, Type interfaceType)
+        {
+            Assumption.AssertNotNull(type, nameof(type));
+            Assumption.AssertNotNull(interfaceType, nameof(interfaceType));
+            Assumption.AssertTrue(interfaceType.IsInterface, nameof(interfaceType));
+
+            return type.GetInterfaces().Any(i => i.FullName == interfaceType.FullName);
+        }
+
     }
 }


### PR DESCRIPTION
fix: ref#457: DTOs that are derivatives of ExtendableDtoBase generate 'key not found' exceptions for optional attributes.