### PR TITLE
- fix: resolve #509

### DIFF
--- a/Rollbar/Infrastructure/InternalRollbarError.cs
+++ b/Rollbar/Infrastructure/InternalRollbarError.cs
@@ -88,5 +88,10 @@
         /// The queue controller error
         /// </summary>
         QueueControllerError,
+
+        /// <summary>
+        /// The connectivity monitor error
+        /// </summary>
+        ConnectivityMonitorError,
     }
 }

--- a/SdkCommon.csproj
+++ b/SdkCommon.csproj
@@ -7,10 +7,10 @@
   
   <PropertyGroup Label="SDK Common NuGet Packaging Info" >
 
-    <SdkVersion>3.9.0</SdkVersion>
+    <SdkVersion>3.9.1</SdkVersion>
     <SdkVersionSuffix></SdkVersionSuffix>
     <PackageReleaseNotes>
-      - feat: resolve #507: Disable ConnectivityMonitor in case a proxy server custom configuration.
+      - fix: resolve #509: ConnectivityMonitor's time disposed when CheckConnectivityStatus(..) is executed in a web proxy runtime environment
     </PackageReleaseNotes>
 
     <!--

--- a/UnitTest.Rollbar/RollbarLiveFixtureBase.cs
+++ b/UnitTest.Rollbar/RollbarLiveFixtureBase.cs
@@ -89,8 +89,8 @@ namespace UnitTest.Rollbar
             {
             }
 
-            //// for basic RollbarRateLimitVerification test:
-            //switch (e)
+            // for basic RollbarRateLimitVerification test:
+            //switch(e)
             //{
             //    case RollbarApiErrorEventArgs apiErrorEvent:
             //        //this.ApiErrorEvents.Add(apiErrorEvent);

--- a/UnitTest.Rollbar/RollbarLoggerFixture.cs
+++ b/UnitTest.Rollbar/RollbarLoggerFixture.cs
@@ -798,6 +798,17 @@ namespace UnitTest.Rollbar
         }
 
         /// <summary>
+        /// Defines the test method MultithreadedStressTest_ConnectivityMonitorDisabled.
+        /// </summary>
+        //[TestMethod]
+        //[Timeout(60000)]
+        //public void MultithreadedStressTest_ConnectivityMonitorDisabled()
+        //{
+        //    ConnectivityMonitor.Instance.Disable();
+        //    MultithreadedStressTest();
+        //}
+
+        /// <summary>
         /// Defines the test method MultithreadedStressTest.
         /// </summary>
         [TestMethod]


### PR DESCRIPTION
- fix: resolve #509: ConnectivityMonitor's time disposed when CheckConnectivityStatus(..) is executed in a web proxy runtime environment