### PR TITLE
fix: resolve #553

### DIFF
--- a/Rollbar/DTOs/ExtendableDtoBase.cs
+++ b/Rollbar/DTOs/ExtendableDtoBase.cs
@@ -100,13 +100,14 @@
             set
             {
                 Assumption.AssertTrue(
-                    !this._keyedValues.ContainsKey(key)                               // no such key preset yet
+                    !this._keyedValues.ContainsKey(key)                                         // no such key preset yet
                     || this._keyedValues[key] == null                                           // OR its not initialized yet
                     || value != null                                                            // OR no-null value
                     || !this._metadata.ReservedPropertyInfoByReservedKey.Keys.Contains(key),    // OR not about reserved property/key
                     "conditional " + nameof(value) + " assessment"
                     );
-//
+
+                var lowCaseKey = key.ToLower();
                 var concreteDtoMetadata = metadataByDerivedType[this.GetType()];
                 if (concreteDtoMetadata
                     .ReservedPropertyInfoByReservedKey
@@ -116,7 +117,7 @@
                     var valueType = value?.GetType();
                     Assumption.AssertTrue(
                         //we are not dealing with a reserved property, hence, anything works:
-                        !concreteDtoMetadata.ReservedPropertyInfoByReservedKey.ContainsKey(key)
+                        !(concreteDtoMetadata.ReservedPropertyInfoByReservedKey.ContainsKey(key) || concreteDtoMetadata.ReservedPropertyInfoByReservedKey.ContainsKey(lowCaseKey))
                         //OR we are dealing with a reserved property and the value and its type should make sense:  
                         || value == null
                         || reservedPropertyType == valueType
@@ -129,8 +130,17 @@
                         nameof(value)
                     );
                 }
-//
-            this._keyedValues[key] = value;
+
+                if(concreteDtoMetadata.ReservedPropertyInfoByReservedKey.ContainsKey(lowCaseKey))
+                {
+                    // we are setting a reserved key when calling Bind(...) on an IConfigurationSection 
+                    // that treats this instance of ExtendableDtoBase as a dictionary while binding to the targeted deserialization object:
+                    this._keyedValues[lowCaseKey] = value;
+                }
+                else
+                {
+                    this._keyedValues[key] = value;
+                }
             }
         }
 

--- a/SdkCommon.csproj
+++ b/SdkCommon.csproj
@@ -11,6 +11,7 @@
     <SdkLtsRelease>true</SdkLtsRelease>             <!-- Optional. Examples: false (default) or true. -->
     <SdkReleaseNotes>                               <!-- Required -->
       - fix: resolve #554: rollbarData.Response is null on this line.
+      - fix: resolve #553: RollbarConfig.Server's properties do not properly deserialize from appsettings.json.
     </SdkReleaseNotes>
 
     <!--

--- a/UnitTest.Rollbar/NetCore/AppSettingsUtilFixture.cs
+++ b/UnitTest.Rollbar/NetCore/AppSettingsUtilFixture.cs
@@ -31,7 +31,12 @@ namespace UnitTest.Rollbar.NetCore
         [TestMethod]
         public void LoadRollbarAppSettingsTest()
         {
+            var sever = new Server();
+
             RollbarConfig config = new RollbarConfig("default=none");
+            Assert.IsNull(config.Person);
+            Assert.IsNull(config.Server);
+
             AppSettingsUtility.LoadAppSettings(config, Path.Combine(Environment.CurrentDirectory, "TestData"), "appsettings.json");
 
             // The test data looks like this:
@@ -47,6 +52,10 @@ namespace UnitTest.Rollbar.NetCore
             //      "ThePassword",
             //      "TheSecret"
             //    ],
+            //    "Server": {
+            //      "Root": "C://Blah/Blah",
+            //      "Cpu": "x64"
+            //    },
             //    "Person": {
             //      "UserName": "jbond"
             //    },
@@ -70,6 +79,16 @@ namespace UnitTest.Rollbar.NetCore
                 IpAddressCollectionPolicy.CollectAnonymized
                 , config.IpAddressCollectionPolicy
                 );
+
+            Assert.IsNotNull(config.Server);
+            Assert.IsTrue(config.Server.ContainsKey("cpu"));
+            Assert.IsTrue(config.Server.ContainsKey("root"));
+            Assert.IsFalse(config.Server.ContainsKey("Cpu"));
+            Assert.IsFalse(config.Server.ContainsKey("Root"));
+            Assert.AreEqual(config.Server["cpu"], config.Server.Cpu);
+            Assert.AreEqual(config.Server["root"], config.Server.Root);
+            Assert.AreEqual("x64", config.Server.Cpu);
+            Assert.AreEqual("C://Blah/Blah", config.Server.Root);
         }
 
         [TestMethod]

--- a/UnitTest.Rollbar/TestData/appsettings.json
+++ b/UnitTest.Rollbar/TestData/appsettings.json
@@ -24,9 +24,12 @@
       "ThePassword",
       "TheSecret"
     ],
+    "Server": {
+      "Root": "C://Blah/Blah",
+      "Cpu": "x64"
+    },
     "Person": {
       "UserName": "jbond"
-
     },
     "PersonDataCollectionPolicies": "Username, Email",
     "IpAddressCollectionPolicy": "CollectAnonymized"


### PR DESCRIPTION
## Description of the change

 - fix: resolve #553: RollbarConfig.Server's properties do not properly deserialize from appsettings.json.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#53](https://github.com/rollbar/Rollbar.NET/issues/553) 
## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
