### PR TITLE
fix: resolve #553, resolve #554

### DIFF
--- a/Rollbar.Net.AspNet.WebApi/HttpActionContextPackageDecorator.cs
+++ b/Rollbar.Net.AspNet.WebApi/HttpActionContextPackageDecorator.cs
@@ -75,7 +75,7 @@
             {
                 rollbarData.Request.Url = this._httpActionContext.Request.RequestUri?.PathAndQuery;
                 rollbarData.Request.Method = this._httpActionContext.Request.Method?.ToString().ToUpper();
-                rollbarData.Response.Headers = Convert(this._httpActionContext.Request.Headers);
+                rollbarData.Request.Headers = Convert(this._httpActionContext.Request.Headers);
                 rollbarData.Request.PostBody = ReadInHttpMessageBody(this._httpActionContext.Request.Content);
                 rollbarData.Request["request_properties"] = this._httpActionContext.Request.Properties;
             }

--- a/Rollbar/DTOs/ExtendableDtoBase.cs
+++ b/Rollbar/DTOs/ExtendableDtoBase.cs
@@ -100,7 +100,7 @@
             set
             {
                 Assumption.AssertTrue(
-                    !this._keyedValues.ContainsKey(key)                               // no such key preset yet
+                    !this._keyedValues.ContainsKey(key)                                         // no such key preset yet
                     || this._keyedValues[key] == null                                           // OR its not initialized yet
                     || value != null                                                            // OR no-null value
                     || !this._metadata.ReservedPropertyInfoByReservedKey.Keys.Contains(key),    // OR not about reserved property/key
@@ -134,7 +134,7 @@
                 if(concreteDtoMetadata.ReservedPropertyInfoByReservedKey.ContainsKey(lowCaseKey))
                 {
                     // we are setting a reserved key when calling Bind(...) on an IConfigurationSection 
-                    // that treats this instance of ExtendableDtoBase as a dictionary while binding to the targeted deserialization onject:
+                    // that treats this instance of ExtendableDtoBase as a dictionary while binding to the targeted deserialization object:
                     this._keyedValues[lowCaseKey] = value;
                 }
                 else

--- a/Rollbar/DTOs/ExtendableDtoBase.cs
+++ b/Rollbar/DTOs/ExtendableDtoBase.cs
@@ -106,7 +106,8 @@
                     || !this._metadata.ReservedPropertyInfoByReservedKey.Keys.Contains(key),    // OR not about reserved property/key
                     "conditional " + nameof(value) + " assessment"
                     );
-//
+
+                var lowCaseKey = key.ToLower();
                 var concreteDtoMetadata = metadataByDerivedType[this.GetType()];
                 if (concreteDtoMetadata
                     .ReservedPropertyInfoByReservedKey
@@ -116,7 +117,7 @@
                     var valueType = value?.GetType();
                     Assumption.AssertTrue(
                         //we are not dealing with a reserved property, hence, anything works:
-                        !concreteDtoMetadata.ReservedPropertyInfoByReservedKey.ContainsKey(key)
+                        !(concreteDtoMetadata.ReservedPropertyInfoByReservedKey.ContainsKey(key) || concreteDtoMetadata.ReservedPropertyInfoByReservedKey.ContainsKey(lowCaseKey))
                         //OR we are dealing with a reserved property and the value and its type should make sense:  
                         || value == null
                         || reservedPropertyType == valueType
@@ -129,8 +130,17 @@
                         nameof(value)
                     );
                 }
-//
-            this._keyedValues[key] = value;
+
+                if(concreteDtoMetadata.ReservedPropertyInfoByReservedKey.ContainsKey(lowCaseKey))
+                {
+                    // we are setting a reserved key when calling Bind(...) on an IConfigurationSection 
+                    // that treats this instance of ExtendableDtoBase as a dictionary while binding to the targeted deserialization onject:
+                    this._keyedValues[lowCaseKey] = value;
+                }
+                else
+                {
+                    this._keyedValues[key] = value;
+                }
             }
         }
 

--- a/SdkCommon.csproj
+++ b/SdkCommon.csproj
@@ -8,11 +8,12 @@
   <PropertyGroup Label="SDK Release Essential Info">
     <SdkVersion>3.12.3</SdkVersion>           <!-- Required: major.minor.patch -->
     <SdkVersionSuffix></SdkVersionSuffix>     <!-- Optional. Examples: alpha, beta, preview, RC etc. -->
-    <SdkLtsRelease>false</SdkLtsRelease> <!-- Optional. Examples: false (default) or true. -->
-    <SdkReleaseNotes>
+    <SdkLtsRelease>false</SdkLtsRelease>      <!-- Optional. Examples: false (default) or true. -->
+    <SdkReleaseNotes>                         <!-- Required -->
+      - fix: resolve #554: rollbarData.Response is null on this line.
       - fix: resolve #553: RollbarConfig.Server's properties do not properly deserialize from appsettings.json.
       - chore: resolve #549: Replace Blacklist and Whitelist with Safelist and Blocklist.
-    </SdkReleaseNotes>                   <!-- Required -->
+    </SdkReleaseNotes>                        
 
     <!--
     Release Notes Tagging Conventions:

--- a/SdkCommon.csproj
+++ b/SdkCommon.csproj
@@ -10,6 +10,7 @@
     <SdkVersionSuffix></SdkVersionSuffix>     <!-- Optional. Examples: alpha, beta, preview, RC etc. -->
     <SdkLtsRelease>false</SdkLtsRelease> <!-- Optional. Examples: false (default) or true. -->
     <SdkReleaseNotes>
+      - fix: resolve #553: RollbarConfig.Server's properties do not properly deserialize from appsettings.json.
       - chore: resolve #549: Replace Blacklist and Whitelist with Safelist and Blocklist.
     </SdkReleaseNotes>                   <!-- Required -->
 

--- a/UnitTest.Rollbar.Net.AspNet.WebApi/HttpActionContextPackageDecoratorFixture.cs
+++ b/UnitTest.Rollbar.Net.AspNet.WebApi/HttpActionContextPackageDecoratorFixture.cs
@@ -1,0 +1,62 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+namespace UnitTest.Rollbar.Net.AspNet.WebApi
+{
+    using global::Rollbar;
+    using global::Rollbar.DTOs;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using System;
+    using System.Collections.Specialized;
+    using System.Net.Http;
+    using System.Security.Principal;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Web.Http.Controllers;
+    using global::Rollbar.Net.AspNet.WebApi;
+
+    [TestClass]
+    [TestCategory(nameof(HttpActionContextPackageDecoratorFixture))]
+    public class HttpActionContextPackageDecoratorFixture
+    {
+
+        [TestInitialize]
+        public void SetupFixture()
+        {
+        }
+
+        [TestCleanup]
+        public void TearDownFixture()
+        {
+        }
+
+        [TestMethod]
+        public void TestHttpActionContextPackageDecorator()
+        {
+            var httpActionContext= FakeHttpActionContext();
+            var package = FakePackege();
+            package = new HttpActionContextPackageDecorator(package, httpActionContext);
+            try
+            {
+                _ = package.RollbarData;
+            }
+            catch(System.Exception ex)
+            {
+                Assert.Fail("No exception expected");
+            }
+        }
+
+        public static IRollbarPackage FakePackege()
+        {
+            var package = new ExceptionPackage(new NotImplementedException("Fake exception"));
+            return package;
+        }
+
+        public static HttpActionContext FakeHttpActionContext()//(string url, string ip, string referrer)
+        {
+            var context = new HttpActionContext();
+            return context;
+        }
+
+    }
+}

--- a/UnitTest.Rollbar.Net.AspNet.WebApi/UnitTest.Rollbar.Net.AspNet.WebApi.csproj
+++ b/UnitTest.Rollbar.Net.AspNet.WebApi/UnitTest.Rollbar.Net.AspNet.WebApi.csproj
@@ -17,4 +17,9 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Rollbar.Net.AspNet.WebApi\Rollbar.Net.AspNet.WebApi.csproj" />
+    <ProjectReference Include="..\Rollbar\Rollbar.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/UnitTest.Rollbar/NetCore/AppSettingsUtilFixture.cs
+++ b/UnitTest.Rollbar/NetCore/AppSettingsUtilFixture.cs
@@ -31,7 +31,12 @@ namespace UnitTest.Rollbar.NetCore
         [TestMethod]
         public void LoadRollbarAppSettingsTest()
         {
+            var sever = new Server();
+
             RollbarConfig config = new RollbarConfig("default=none");
+            Assert.IsNull(config.Person);
+            Assert.IsNull(config.Server);
+
             AppSettingsUtility.LoadAppSettings(config, Path.Combine(Environment.CurrentDirectory, "TestData"), "appsettings.json");
 
             // The test data looks like this:
@@ -47,6 +52,10 @@ namespace UnitTest.Rollbar.NetCore
             //      "ThePassword",
             //      "TheSecret"
             //    ],
+            //    "Server": {
+            //      "Root": "C://Blah/Blah",
+            //      "Cpu": "x64"
+            //    },
             //    "Person": {
             //      "UserName": "jbond"
             //    },
@@ -70,6 +79,16 @@ namespace UnitTest.Rollbar.NetCore
                 IpAddressCollectionPolicy.CollectAnonymized
                 , config.IpAddressCollectionPolicy
                 );
+
+            Assert.IsNotNull(config.Server);
+            Assert.IsTrue(config.Server.ContainsKey("cpu"));
+            Assert.IsTrue(config.Server.ContainsKey("root"));
+            Assert.IsFalse(config.Server.ContainsKey("Cpu"));
+            Assert.IsFalse(config.Server.ContainsKey("Root"));
+            Assert.AreEqual(config.Server["cpu"], config.Server.Cpu);
+            Assert.AreEqual(config.Server["root"], config.Server.Root);
+            Assert.AreEqual("x64", config.Server.Cpu);
+            Assert.AreEqual("C://Blah/Blah", config.Server.Root);
         }
 
         [TestMethod]

--- a/UnitTest.Rollbar/TestData/appsettings.json
+++ b/UnitTest.Rollbar/TestData/appsettings.json
@@ -24,9 +24,12 @@
       "ThePassword",
       "TheSecret"
     ],
+    "Server": {
+      "Root": "C://Blah/Blah",
+      "Cpu": "x64"
+    },
     "Person": {
       "UserName": "jbond"
-
     },
     "PersonDataCollectionPolicies": "Username, Email",
     "IpAddressCollectionPolicy": "CollectAnonymized"


### PR DESCRIPTION
## Description of the change
- fix: resolve #554: rollbarData.Response is null on this line.
- fix: resolve #553: RollbarConfig.Server's properties do not properly deserialize from appsettings.json.

> Description here
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#554](https://github.com/rollbar/Rollbar.NET/issues/554) 
> Fix [#553](https://github.com/rollbar/Rollbar.NET/issues/553) 
## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
