### PR TITLE
- fix: merge PR resolve #583 - Rollbar 4.0.2 crashes Xamarin.Forms-App

### DIFF
--- a/Rollbar.NetCore.AspNet/HttpResponsePackageDecorator.cs
+++ b/Rollbar.NetCore.AspNet/HttpResponsePackageDecorator.cs
@@ -90,10 +90,10 @@
             }
             rollbarData.Response.Body = jsonString;
 
-            object requesBodyObject = JsonUtil.InterpretAsJsonObject(jsonString);
-            if (requesBodyObject != null)
+            object responseBodyObject = JsonUtil.InterpretAsJsonObject(jsonString);
+            if (responseBodyObject != null)
             {
-                rollbarData.Response.Body = requesBodyObject;
+                rollbarData.Response.Body = responseBodyObject;
             }
         }
 

--- a/Rollbar/Common/RuntimeEnvironmentUtility.cs
+++ b/Rollbar/Common/RuntimeEnvironmentUtility.cs
@@ -6,9 +6,7 @@ namespace Rollbar.Common
     using System.Runtime.InteropServices;
     using System.Runtime.Versioning;
     using System.Text;
-#if (NETFX)
     using System.IO;
-#endif
 
     /// <summary>
     /// A utility class aiding discovery of the current runtime environment.
@@ -21,13 +19,25 @@ namespace Rollbar.Common
         /// <returns>System.String.</returns>
         public static string GetSdkRuntimeLocationPath()
         {
-#if (NETFX)
-            Assembly thisAssembly = Assembly.GetExecutingAssembly();
-            string sdkAssembliesPath = Path.GetDirectoryName(thisAssembly.Location);
-            return sdkAssembliesPath;
-#else
-            return AppContext.BaseDirectory;
+            string path = null;
+
+#if (!NETFX || NETFX_461nNewer)
+            path = AppContext.BaseDirectory;
 #endif
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                Assembly thisAssembly = Assembly.GetExecutingAssembly();
+                string sdkAssembliesPath = Path.GetDirectoryName(thisAssembly.Location);
+                path = sdkAssembliesPath;
+            }
+
+            if (path != null)
+            {
+                return path;
+            }
+
+            return string.Empty;
         }
 
         /// <summary>

--- a/SdkCommon.csproj
+++ b/SdkCommon.csproj
@@ -21,11 +21,11 @@
   </ItemGroup>
   
   <PropertyGroup Label="SDK Release Essential Info">
-    <SdkVersion>4.0.2</SdkVersion>           <!-- Required: major.minor.patch -->
+    <SdkVersion>4.0.3</SdkVersion>           <!-- Required: major.minor.patch -->
     <SdkVersionSuffix></SdkVersionSuffix>     <!-- Optional. Examples: alpha, beta, preview, RC etc. -->
     <SdkLtsRelease>false</SdkLtsRelease>      <!-- Optional. Examples: false (default) or true. -->
     <SdkReleaseNotes>                         <!-- Required -->
-      - fix: merge PR resolve #581 - Single file app fix
+      - fix: merge PR resolve #583 - Rollbar 4.0.2 crashes Xamarin.Forms-App
     </SdkReleaseNotes>                        
 
     <!--


### PR DESCRIPTION
## Description of the change

> - fix: merge PR resolve #583 - Rollbar 4.0.2 crashes Xamarin.Forms-App
>         the APIs we use to identify runtime directory vary their availability from one .NET flavor/version to another,
>         as well as their behavior change based on .NET flavor/version. This fix uses safer implementation 
>         to take it all into account.
>
> - fixing a typo in HttpResponsePackageDecorator

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix #583 

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
