### PR TITLE
Hot fix of Telemetry with NetExtensions and RollbarMiddleware

### DIFF
--- a/Rollbar.NetCore.AspNet/RollbarMiddleware.cs
+++ b/Rollbar.NetCore.AspNet/RollbarMiddleware.cs
@@ -141,9 +141,12 @@ namespace Rollbar.NetCore.AspNet
             this._logger = loggerFactory.CreateLogger<RollbarMiddleware>();
             this._rollbarOptions = rollbarOptions.Value;
 
-            RollbarConfigurationUtil.DeduceRollbarTelemetryConfig(configuration);
-            RollbarInfrastructure.Instance?.TelemetryCollector?.StartAutocollection();
-            RollbarConfigurationUtil.DeduceRollbarConfig(configuration);
+            if (!RollbarInfrastructure.Instance.IsInitialized)
+            {
+                RollbarConfigurationUtil.DeduceRollbarTelemetryConfig(configuration);
+                RollbarInfrastructure.Instance?.TelemetryCollector?.StartAutocollection();
+                RollbarConfigurationUtil.DeduceRollbarConfig(configuration);
+            }
         }
 
         /// <summary>

--- a/Rollbar.NetPlatformExtensions/RollbarLoggerProvider.cs
+++ b/Rollbar.NetPlatformExtensions/RollbarLoggerProvider.cs
@@ -69,17 +69,12 @@
         {
             if(configuration != null)
             {
-                this._rollbarInfrastructureConfig = RollbarConfigurationUtil.DeduceRollbarConfig(configuration);
-                if(RollbarInfrastructure.Instance.IsInitialized)
+                if (!RollbarInfrastructure.Instance.IsInitialized)
                 {
-                    RollbarInfrastructure.Instance.Config.Reconfigure(this._rollbarInfrastructureConfig);
-                }
-                else
-                {
+                    this._rollbarInfrastructureConfig = RollbarConfigurationUtil.DeduceRollbarConfig(configuration);
                     RollbarInfrastructure.Instance.Init(this._rollbarInfrastructureConfig);
                 }
-                RollbarConfigurationUtil.DeduceRollbarTelemetryConfig(configuration);
-                _ = Rollbar.RollbarInfrastructure.Instance?.TelemetryCollector?.StartAutocollection();
+                this._rollbarInfrastructureConfig = RollbarInfrastructure.Instance.Config;
             }
 
             if(options != null)

--- a/Rollbar/Config/_Config.cd
+++ b/Rollbar/Config/_Config.cd
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ClassDiagram MajorVersion="1" MinorVersion="1" MembersFormat="FullSignature">
+  <Class Name="Rollbar.HttpProxyOptions">
+    <Position X="24.25" Y="11.75" Width="7.25" />
+    <TypeIdentifier>
+      <HashCode>AAAAACAAAAAAAAAAAAAAgAACAAIAAAACAAAAEAAAAAA=</HashCode>
+      <FileName>Config\HttpProxyOptions.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="Rollbar.RollbarDataSecurityOptions">
+    <Position X="15.25" Y="12.5" Width="5.75" />
+    <TypeIdentifier>
+      <HashCode>AAAAACBACAIAAQAAAAAAgAAAAgAAAAAAIAAAAAAAAAA=</HashCode>
+      <FileName>Config\RollbarDataSecurityOptions.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="Rollbar.RollbarDestinationOptions">
+    <Position X="21" Y="0.5" Width="10.5" />
+    <Compartments>
+      <Compartment Name="Nested Types" Collapsed="false" />
+    </Compartments>
+    <NestedTypes>
+      <Enum Name="Rollbar.RollbarDestinationOptions.RollbarDestinationOptionsValidationRule">
+        <TypeIdentifier>
+          <NewMemberFileName>Config\RollbarDestinationOptions.cs</NewMemberFileName>
+        </TypeIdentifier>
+      </Enum>
+    </NestedTypes>
+    <TypeIdentifier>
+      <HashCode>AAAAACACAAAASAAAAAAAgAAAEAAgAAAAAAAAAAAAAIA=</HashCode>
+      <FileName>Config\RollbarDestinationOptions.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="Rollbar.RollbarDeveloperOptions">
+    <Position X="21" Y="6.5" Width="10.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAACgAIAAAAICABAAAwAAEAAAAAAIIBAAEBAQAAAA=</HashCode>
+      <FileName>Config\RollbarDeveloperOptions.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="Rollbar.RollbarInfrastructureConfig">
+    <Position X="0.5" Y="0.5" Width="9.5" />
+    <NestedTypes>
+      <Enum Name="Rollbar.RollbarInfrastructureConfig.RollbarInfrastructureConfigValidationRule" Collapsed="true">
+        <TypeIdentifier>
+          <NewMemberFileName>Config\RollbarInfrastructureConfig.cs</NewMemberFileName>
+        </TypeIdentifier>
+      </Enum>
+    </NestedTypes>
+    <TypeIdentifier>
+      <HashCode>AEAAASAABAAABAAAEgAAgAAiAAAAAAAIAAAAAAAAAAA=</HashCode>
+      <FileName>Config\RollbarInfrastructureConfig.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="Rollbar.RollbarInfrastructureOptions">
+    <Position X="1" Y="16" Width="20.25" />
+    <TypeIdentifier>
+      <HashCode>AAgACCAAACAAAAAAAABA2AAAAABAAAAIAAAAAAAAAAQ=</HashCode>
+      <FileName>Config\RollbarInfrastructureOptions.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="Rollbar.RollbarLoggerConfig">
+    <Position X="12.75" Y="0.5" Width="8" />
+    <NestedTypes>
+      <Enum Name="Rollbar.RollbarLoggerConfig.RollbarLoggerConfigValidationRule" Collapsed="true">
+        <TypeIdentifier>
+          <NewMemberFileName>Config\RollbarLoggerConfig.cs</NewMemberFileName>
+        </TypeIdentifier>
+      </Enum>
+    </NestedTypes>
+    <TypeIdentifier>
+      <HashCode>CAAAAWgQQAIBAQAACAwAwAAAIAAAAAAgDAAgAAAIABg=</HashCode>
+      <FileName>Config\RollbarLoggerConfig.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="Rollbar.RollbarOfflineStoreOptions">
+    <Position X="11.25" Y="8.25" Width="9.5" />
+    <TypeIdentifier>
+      <HashCode>ABACACAAAAAAAICAAAAAgAAAAAAAAAAQAACAAACAEAA=</HashCode>
+      <FileName>Config\RollbarOfflineStoreOptions.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="Rollbar.RollbarPayloadAdditionOptions">
+    <Position X="0.5" Y="5.25" Width="10.25" />
+    <Compartments>
+      <Compartment Name="Nested Types" Collapsed="false" />
+    </Compartments>
+    <NestedTypes>
+      <Enum Name="Rollbar.RollbarPayloadAdditionOptions.RollbarPayloadAdditionOptionsValidationRule">
+        <TypeIdentifier>
+          <NewMemberFileName>Config\RollbarPayloadAdditionOptions.cs</NewMemberFileName>
+        </TypeIdentifier>
+      </Enum>
+    </NestedTypes>
+    <TypeIdentifier>
+      <HashCode>AIAACDAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAgAEAAA=</HashCode>
+      <FileName>Config\RollbarPayloadAdditionOptions.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="Rollbar.RollbarPayloadManipulationOptions">
+    <Position X="0.5" Y="12.75" Width="11.5" />
+    <TypeIdentifier>
+      <HashCode>AAACACAAAAAAAAAAAAAAgAUCAAAAAAAQAAAAAAAAAAA=</HashCode>
+      <FileName>Config\RollbarPayloadManipulationOptions.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="Rollbar.RollbarTelemetryOptions">
+    <Position X="22.75" Y="15" Width="8" />
+    <TypeIdentifier>
+      <HashCode>AAAIACAAAAAAAFAAAAAigAAAAAAAAAAAAAACABAAAAI=</HashCode>
+      <FileName>Config\RollbarTelemetryOptions.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Font Name="Segoe UI" Size="9" />
+</ClassDiagram>

--- a/Rollbar/DTOs/Notifier.cs
+++ b/Rollbar/DTOs/Notifier.cs
@@ -28,6 +28,10 @@
             /// The configuration
             /// </summary>
             public static readonly string Configuration = "configured_options";
+            /// <summary>
+            /// The Rollbar Infrastructure configuration
+            /// </summary>
+            public static readonly string InfrastructureConfiguration = "infrastructure_options";
         }
 
         /// <summary>
@@ -85,6 +89,21 @@
             get { return this[ReservedProperties.Configuration] as IRollbarLoggerConfig; }
             set { this[ReservedProperties.Configuration] = value; }
         }
+        /// <summary>
+        /// Gets or sets the Rollbar Infrastructure configuration.
+        /// </summary>
+        /// <value>The configuration.</value>
+        public IRollbarInfrastructureConfig? InfrastructureConfiguration
+        {
+            get
+            {
+                return this[ReservedProperties.InfrastructureConfiguration] as IRollbarInfrastructureConfig;
+            }
+            private set
+            {
+                this[ReservedProperties.InfrastructureConfiguration] = value;
+            }
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Notifier"/> class.
@@ -103,6 +122,11 @@
         {
             this.Name = Notifier.notifierName;
             this.Version = Notifier.notifierAssemblyVersion;
+
+            if (RollbarInfrastructure.Instance.IsInitialized)
+            {
+                this.InfrastructureConfiguration = RollbarInfrastructure.Instance.Config;
+            }
         }
     }
 }

--- a/Rollbar/Telemetry/RollbarTelemetryCollector.cs
+++ b/Rollbar/Telemetry/RollbarTelemetryCollector.cs
@@ -53,8 +53,6 @@
 
             this._config = options;
 
-
-
             if (this._config != null)
             {
                 // let's resync with relevant config settings: 

--- a/Rollbar/Telemetry/RollbarTelemetryCollector.cs
+++ b/Rollbar/Telemetry/RollbarTelemetryCollector.cs
@@ -4,7 +4,6 @@
     using System.Diagnostics;
     using System.Threading;
 
-    using Rollbar;
     using Rollbar.DTOs;
 
     /// <summary>
@@ -37,6 +36,8 @@
         internal RollbarTelemetryCollector()
         {
             traceSource.TraceInformation($"Creating the {typeof(RollbarTelemetryCollector).Name}...");
+
+            this._telemetryQueue.QueueDepth = 0; // since we do not have valid telemetry config assigned yet...
         }
 
         #endregion singleton implementation
@@ -51,11 +52,20 @@
             }
 
             this._config = options;
-            
-            if(this._config != null)
+
+
+
+            if (this._config != null)
             {
+                // let's resync with relevant config settings: 
+                this._telemetryQueue.QueueDepth = this._config.TelemetryQueueDepth;
+
                 this._config.Reconfigured += _config_Reconfigured;
                 this.StartAutocollection();
+            }
+            else
+            {
+                this._telemetryQueue.QueueDepth = 0;
             }
         }
 
@@ -141,9 +151,6 @@
             {
                 return this; // this, essentially, means the auto-collection is off...
             }
-
-            // let's resync with relevant config settings: 
-            this._telemetryQueue.QueueDepth = this.Config.TelemetryQueueDepth;
 
             lock (_syncRoot)
             {

--- a/Rollbar/_Rollbar.cd
+++ b/Rollbar/_Rollbar.cd
@@ -54,7 +54,7 @@
       <Compartment Name="Nested Types" Collapsed="false" />
     </Compartments>
     <NestedTypes>
-      <Enum Name="Rollbar.Infrastructure.RollbarQueueController.PayloadTraceSources" Collapsed="true">
+      <Enum Name="Rollbar.Infrastructure.RollbarQueueController.PayloadTraceSources">
         <TypeIdentifier>
           <NewMemberFileName>Infrastructure\RollbarQueueController.cs</NewMemberFileName>
         </TypeIdentifier>
@@ -86,7 +86,7 @@
     <Lollipop Position="0.2" />
   </Class>
   <Interface Name="Rollbar.IRollbar">
-    <Position X="0.5" Y="11.5" Width="5.5" />
+    <Position X="0.5" Y="11" Width="5.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAgIAAAAAQABAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
       <FileName>IRollbar.cs</FileName>

--- a/Rollbar/_RollbarConfig.cd
+++ b/Rollbar/_RollbarConfig.cd
@@ -1,35 +1,35 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ClassDiagram MajorVersion="1" MinorVersion="1" MembersFormat="FullSignature">
   <Interface Name="Rollbar.IHttpProxyOptions">
-    <Position X="0.75" Y="8.25" Width="2.75" />
+    <Position X="0.5" Y="12.5" Width="4.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAAAAAAAAACAAIAAAACAAAAAAAAAAA=</HashCode>
       <FileName>IHttpProxyOptions.cs</FileName>
     </TypeIdentifier>
   </Interface>
   <Interface Name="Rollbar.IRollbarDataSecurityOptions">
-    <Position X="0.5" Y="12.5" Width="4.5" />
+    <Position X="0.5" Y="16.5" Width="4.5" />
     <TypeIdentifier>
       <HashCode>AAAAAABACAAAAQAAAAAAAAAAAgAAAAAAIAAAAAAAAAA=</HashCode>
       <FileName>IRollbarDataSecurityOptions.cs</FileName>
     </TypeIdentifier>
   </Interface>
   <Interface Name="Rollbar.IRollbarDestinationOptions">
-    <Position X="0.75" Y="6.5" Width="2.5" />
+    <Position X="0.75" Y="6" Width="4.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAACAAAAQAAAAAAAAAAAEAAAAAAAAAAAAAAAAAA=</HashCode>
       <FileName>IRollbarDestinationOptions.cs</FileName>
     </TypeIdentifier>
   </Interface>
   <Interface Name="Rollbar.IRollbarDeveloperOptions">
-    <Position X="0.5" Y="10.25" Width="3.5" />
+    <Position X="0.5" Y="10" Width="4.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAIAAAAAAAAAAAAAAAAIIAAAEBAQAAAA=</HashCode>
       <FileName>IRollbarDeveloperOptions.cs</FileName>
     </TypeIdentifier>
   </Interface>
   <Interface Name="Rollbar.IRollbarInfrastructureOptions">
-    <Position X="6.25" Y="8" Width="2.75" />
+    <Position X="6.5" Y="7.75" Width="5" />
     <TypeIdentifier>
       <HashCode>AAAACAAAAAAAAAAAAAAAEAAAAABAAAAIAAAAAAAAAAA=</HashCode>
       <FileName>IRollbarInfrastructureOptions.cs</FileName>
@@ -43,14 +43,14 @@
     </TypeIdentifier>
   </Interface>
   <Interface Name="Rollbar.IRollbarPayloadAdditionOptions">
-    <Position X="4.5" Y="10.25" Width="2.5" />
+    <Position X="0.5" Y="14.5" Width="5" />
     <TypeIdentifier>
       <HashCode>AIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAA=</HashCode>
       <FileName>IRollbarPayloadAdditionOptions.cs</FileName>
     </TypeIdentifier>
   </Interface>
   <Interface Name="Rollbar.IRollbarPayloadManipulationOptions">
-    <Position X="5.25" Y="12.5" Width="3.25" />
+    <Position X="0.5" Y="8" Width="5.25" />
     <TypeIdentifier>
       <HashCode>AAACAAAAAAAAAAAAAAAAAAUAAAAAAAAAAAAAAAAAAAA=</HashCode>
       <FileName>IRollbarPayloadManipulationOptions.cs</FileName>
@@ -64,14 +64,14 @@
     </TypeIdentifier>
   </Interface>
   <Interface Name="Rollbar.IRollbarInfrastructureConfig">
-    <Position X="6" Y="3.25" Width="4.5" />
+    <Position X="6.5" Y="3.25" Width="4.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAABAAABAAAAAAAAAAgAAAAAAAIAAAAAAAAAAA=</HashCode>
       <FileName>IRollbarInfrastructureConfig.cs</FileName>
     </TypeIdentifier>
   </Interface>
   <Interface Name="Rollbar.IRollbarOfflineStoreOptions">
-    <Position X="6.25" Y="6" Width="3.75" />
+    <Position X="6.5" Y="5.75" Width="5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAICAAAAAAAAAAAAAAAAAAAAAAACAAAA=</HashCode>
       <FileName>IRollbarOfflineStoreOptions.cs</FileName>
@@ -89,6 +89,13 @@
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
       <FileName>Common\IReconfigurable.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="Rollbar.IRollbarTelemetryOptions">
+    <Position X="6.5" Y="10.25" Width="4" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAABAAAAACAAAAAAAAAAAAAAACABAAAAA=</HashCode>
+      <FileName>IRollbarTelemetryOptions.cs</FileName>
     </TypeIdentifier>
   </Interface>
   <Enum Name="Rollbar.ErrorLevel">

--- a/SdkCommon.csproj
+++ b/SdkCommon.csproj
@@ -24,12 +24,13 @@
   </ItemGroup>
   
   <PropertyGroup Label="SDK Release Essential Info">
-    <SdkVersion>5.1.2</SdkVersion>           <!-- Required: major.minor.patch -->
+    <SdkVersion>5.1.3</SdkVersion>           <!-- Required: major.minor.patch -->
     <SdkVersionSuffix></SdkVersionSuffix>     <!-- Optional. Examples: alpha, beta, preview, RC etc. -->
     <SdkLtsRelease>false</SdkLtsRelease>      <!-- Optional. Examples: false (default) or true. -->
     <SdkReleaseNotes>                         <!-- Required -->
 
-		fix: resolve #623 - NullReference exception while initializing RollbarInfrastructure
+		fix:  resolve #626 - Telemetry in DotNet Core 3.1 is not initialized
+		feat: resolve #627 - Capture RollbarInfrastructureConfig with each payload
 
 	</SdkReleaseNotes>                        
 

--- a/UnitTest.Rollbar/DTOs/DataFixture.cs
+++ b/UnitTest.Rollbar/DTOs/DataFixture.cs
@@ -57,7 +57,7 @@
             var version = typeof(Data).Assembly.GetName().Version.ToString(3);
             string[] expected = string.Format("{{`name`:`Rollbar.NET`,`version`:`{0}`}}", version).TrimEnd('}').TrimEnd('`').Split(',');
             string[] actual = WhiteSpace.Replace(JsonConvert.SerializeObject(_basicData.Notifier), "").Replace('"', '`').Split(',');
-            Assert.AreEqual(2, actual.Length);
+            Assert.IsTrue(actual.Length >= 2);
             Assert.IsTrue(actual[0].StartsWith(expected[0].TrimEnd('`'))); // for name:
             Assert.IsTrue(actual[1].StartsWith(expected[1])); // for version:
         }

--- a/UnitTest.Rollbar/DTOs/PayloadFixture.cs
+++ b/UnitTest.Rollbar/DTOs/PayloadFixture.cs
@@ -84,14 +84,17 @@ namespace UnitTest.Rollbar.DTOs
             Assert.AreEqual("c#", data["language"].Value<string>());
 
             var left = exceptionExample.Data.Notifier.ToArray();
-            var right = data["notifier"].ToObject<Dictionary<string, string>>();
+            var right = data["notifier"].ToObject<Dictionary<string, object>>();
 
             Assert.AreEqual(left.Length, right.Count);
             int i = 0;
             while (i < right.Count)
             {
                 Assert.IsTrue(right.ContainsKey(left[i].Key));
-                Assert.AreEqual(right[left[i].Key], left[i].Value);
+                if (left[i].Value is String)
+                {
+                    Assert.AreEqual(right[left[i].Key], left[i].Value);
+                }
                 i++;
             }
 
@@ -164,14 +167,17 @@ namespace UnitTest.Rollbar.DTOs
             Assert.AreEqual("c#", data["language"].Value<string>());
 
             var left = messageException.Data.Notifier.ToArray();
-            var right = data["notifier"].ToObject<Dictionary<string, string>>();
+            var right = data["notifier"].ToObject<Dictionary<string, object>>();
 
             Assert.AreEqual(left.Length, right.Count);
             int i = 0;
             while (i < right.Count)
             {
                 Assert.IsTrue(right.ContainsKey(left[i].Key));
-                Assert.AreEqual(right[left[i].Key], left[i].Value);
+                if (left[i].Value is String)
+                {
+                    Assert.AreEqual(right[left[i].Key], left[i].Value);
+                }
                 i++;
             }
 
@@ -274,14 +280,17 @@ namespace UnitTest.Rollbar.DTOs
 
             //Assert.AreEqual(_exceptionExample.Data.Notifier.ToArray(), data["notifier"].ToObject<Dictionary<string, string>>());
             var left = aggregateExample.Data.Notifier.ToArray();
-            var right = data["notifier"].ToObject<Dictionary<string, string>>();
+            var right = data["notifier"].ToObject<Dictionary<string, object>>();
 
             Assert.AreEqual(left.Length, right.Count);
             int i = 0;
             while (i < right.Count)
             {
                 Assert.IsTrue(right.ContainsKey(left[i].Key));
-                Assert.AreEqual(right[left[i].Key], left[i].Value);
+                if (left[i].Value is String)
+                {
+                    Assert.AreEqual(right[left[i].Key], left[i].Value);
+                }
                 i++;
             }
 
@@ -354,14 +363,17 @@ namespace UnitTest.Rollbar.DTOs
             Assert.AreEqual("c#", data["language"].Value<string>());
 
             var left = crashException.Data.Notifier.ToArray();
-            var right = data["notifier"].ToObject<Dictionary<string, string>>();
+            var right = data["notifier"].ToObject<Dictionary<string, object>>();
 
             Assert.AreEqual(left.Length, right.Count);
             int i = 0;
             while (i < right.Count)
             {
                 Assert.IsTrue(right.ContainsKey(left[i].Key));
-                Assert.AreEqual(right[left[i].Key], left[i].Value);
+                if (left[i].Value is String)
+                {
+                    Assert.AreEqual(right[left[i].Key], left[i].Value);
+                }
                 i++;
             }
 

--- a/UnitTest.Rollbar/RollbarInfrastructureConfigFixture.cs
+++ b/UnitTest.Rollbar/RollbarInfrastructureConfigFixture.cs
@@ -3,6 +3,8 @@
 namespace UnitTest.Rollbar
 {
     using global::Rollbar;
+    using global::Rollbar.DTOs;
+
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System;
     using System.Collections.Generic;
@@ -15,6 +17,16 @@ namespace UnitTest.Rollbar
         [TestInitialize]
         public void SetupFixture()
         {
+            //var config = new RollbarInfrastructureConfig("access_token", "special_environment");
+
+            //if (RollbarInfrastructure.Instance.IsInitialized)
+            //{
+            //    RollbarInfrastructure.Instance.Config.Reconfigure(config);
+            //}
+            //else
+            //{
+            //    RollbarInfrastructure.Instance.Init(config);
+            //}
         }
 
         [TestCleanup]
@@ -36,6 +48,69 @@ namespace UnitTest.Rollbar
                 Console.WriteLine($"  {result}");
             }
             Console.WriteLine();
+        }
+
+
+        [TestMethod]
+        public void CustomTelemetryOptionsReconfigured()
+        {
+            int expectedTelemetryQueueDepth = 20;
+
+            var config = new RollbarInfrastructureConfig("access_token", "special_environment");
+
+            Assert.IsFalse(config.RollbarTelemetryOptions.TelemetryEnabled);
+            Assert.IsTrue(config.RollbarTelemetryOptions.TelemetryQueueDepth != expectedTelemetryQueueDepth);
+            Assert.IsTrue(config.RollbarTelemetryOptions.TelemetryAutoCollectionTypes == TelemetryType.None);
+
+            var telemetryOptions = new RollbarTelemetryOptions(true, 20)
+            {
+                TelemetryAutoCollectionTypes = TelemetryType.Log | TelemetryType.Error | TelemetryType.Network
+            };
+            config.RollbarTelemetryOptions.Reconfigure(telemetryOptions);
+
+            Assert.IsTrue(config.RollbarTelemetryOptions.TelemetryEnabled);
+            Assert.AreEqual(expectedTelemetryQueueDepth, config.RollbarTelemetryOptions.TelemetryQueueDepth);
+            Assert.IsTrue((config.RollbarTelemetryOptions.TelemetryAutoCollectionTypes & TelemetryType.Log) == TelemetryType.Log);
+            Assert.IsTrue((config.RollbarTelemetryOptions.TelemetryAutoCollectionTypes & TelemetryType.Error) == TelemetryType.Error);
+            Assert.IsTrue((config.RollbarTelemetryOptions.TelemetryAutoCollectionTypes & TelemetryType.Network) == TelemetryType.Network);
+            Assert.IsTrue((config.RollbarTelemetryOptions.TelemetryAutoCollectionTypes & TelemetryType.Manual) == TelemetryType.None);
+        }
+
+        [TestMethod]
+        public void CustomTelemetryOptionsMakeIntoTelemetryCollector()
+        {
+            int expectedTelemetryQueueDepth = 20;
+
+            var config = new RollbarInfrastructureConfig("access_token", "special_environment");
+
+            Assert.IsFalse(config.RollbarTelemetryOptions.TelemetryEnabled);
+            Assert.IsTrue(config.RollbarTelemetryOptions.TelemetryQueueDepth != expectedTelemetryQueueDepth);
+            Assert.IsTrue(config.RollbarTelemetryOptions.TelemetryAutoCollectionTypes == TelemetryType.None);
+
+            var telemetryOptions = new RollbarTelemetryOptions(true, 20)
+            {
+                TelemetryAutoCollectionTypes = TelemetryType.Log | TelemetryType.Error | TelemetryType.Network
+            };
+            config.RollbarTelemetryOptions.Reconfigure(telemetryOptions);
+
+
+            if (RollbarInfrastructure.Instance.IsInitialized)
+            {
+                RollbarInfrastructure.Instance.Config.Reconfigure(config);
+            }
+            else
+            {
+                RollbarInfrastructure.Instance.Init(config);
+            }
+
+            Assert.IsTrue(RollbarInfrastructure.Instance.TelemetryCollector.Config.TelemetryEnabled);
+            Assert.AreEqual(expectedTelemetryQueueDepth, RollbarInfrastructure.Instance.TelemetryCollector.Config.TelemetryQueueDepth);
+            Assert.IsTrue((RollbarInfrastructure.Instance.TelemetryCollector.Config.TelemetryAutoCollectionTypes & TelemetryType.Log) == TelemetryType.Log);
+            Assert.IsTrue((RollbarInfrastructure.Instance.TelemetryCollector.Config.TelemetryAutoCollectionTypes & TelemetryType.Error) == TelemetryType.Error);
+            Assert.IsTrue((RollbarInfrastructure.Instance.TelemetryCollector.Config.TelemetryAutoCollectionTypes & TelemetryType.Network) == TelemetryType.Network);
+            Assert.IsTrue((RollbarInfrastructure.Instance.TelemetryCollector.Config.TelemetryAutoCollectionTypes & TelemetryType.Manual) == TelemetryType.None);
+
+            Assert.AreEqual(expectedTelemetryQueueDepth, RollbarInfrastructure.Instance.TelemetryCollector.QueueDepth);
         }
 
     }


### PR DESCRIPTION
## Description of the change

> fix:  resolve #626 - Telemetry in DotNet Core 3.1 is not initialized
> feat: resolve #627 - Capture RollbarInfrastructureConfig with each payload

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [x] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix #626
- Feature  #627

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
