### PR TITLE
Search for config loader assembly in bin subfolder

### DIFF
--- a/Rollbar/Common/RuntimeEnvironmentUtility.cs
+++ b/Rollbar/Common/RuntimeEnvironmentUtility.cs
@@ -32,6 +32,11 @@ namespace Rollbar.Common
 
             if (path != null)
             {
+                if (Directory.Exists(Path.Combine(path, "bin")))
+                {
+                    return Path.Combine(path, "bin");
+                }
+
                 return path;
             }
 #endif

--- a/UnitTest.Rollbar/Common/RuntimeEnvironmentUtilityFixture.cs
+++ b/UnitTest.Rollbar/Common/RuntimeEnvironmentUtilityFixture.cs
@@ -5,6 +5,7 @@
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System;
     using System.Diagnostics;
+    using System.IO;
     using System.Linq;
     using System.Text;
     using System.Threading;
@@ -40,5 +41,26 @@
             Assert.IsFalse(string.IsNullOrWhiteSpace(path));
         }
 
+        [TestMethod]
+        public void TestGetSdkRuntimeLocationPathWithBinSubfolder()
+        {
+            var expectedPath = Path.Combine(AppContext.BaseDirectory, "bin");
+            try
+            {
+                Directory.CreateDirectory(expectedPath);
+
+                var path = RuntimeEnvironmentUtility.GetSdkRuntimeLocationPath();
+                Assert.IsNotNull(path);
+                Assert.IsFalse(string.IsNullOrWhiteSpace(path));
+                Assert.IsTrue(path.EndsWith("bin"));
+            }
+            finally
+            {
+                if (Directory.Exists(expectedPath))
+                {
+                    Directory.Delete(expectedPath);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description of the change

In some .Net projects the assemblies are output to the "bin" subfolder, and the execution context is in the parent folder. This change checks for the existence of the "bin" folder and uses that when present.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues
- Fix #636

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
