### PR TITLE
[SC-132805] Temporarily disable tests preventing the CI build to complete

### DIFF
--- a/UnitTest.Rollbar.Deploys/RollbarDeployClientFixture.cs
+++ b/UnitTest.Rollbar.Deploys/RollbarDeployClientFixture.cs
@@ -20,9 +20,9 @@ namespace UnitTest.Rollbar.Deploys
         {
             SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
 
-            RollbarDestinationOptions destinationOptions = 
+            RollbarDestinationOptions destinationOptions =
                 new RollbarDestinationOptions(
-                    RollbarUnitTestSettings.AccessToken, 
+                    RollbarUnitTestSettings.AccessToken,
                     RollbarUnitTestSettings.Environment
                     );
             this._loggerConfig =
@@ -35,6 +35,7 @@ namespace UnitTest.Rollbar.Deploys
         {
         }
 
+        [Ignore]
         [TestMethod]
         public void TestGetDeploysPage()
         {
@@ -51,6 +52,7 @@ namespace UnitTest.Rollbar.Deploys
 
         }
 
+        [Ignore]
         [TestMethod]
         public void TestGetDeploy()
         {
@@ -67,6 +69,7 @@ namespace UnitTest.Rollbar.Deploys
 
         }
 
+        [Ignore]
         [TestMethod]
         public void TestPostDeployment()
         {

--- a/UnitTest.Rollbar.Deploys/RollbarDeploysManagerFixture.cs
+++ b/UnitTest.Rollbar.Deploys/RollbarDeploysManagerFixture.cs
@@ -15,7 +15,7 @@ namespace UnitTest.Rollbar.Deploys
     [TestCategory(nameof(RollbarDeploysManagerFixture))]
     public class RollbarDeploysManagerFixture
     {
-        private readonly IRollbarDeploysManager _deploysManager = 
+        private readonly IRollbarDeploysManager _deploysManager =
             RollbarDeploysManagerFactory.CreateRollbarDeploysManager(
                 RollbarUnitTestSettings.AccessToken,
                 RollbarUnitTestSettings.DeploymentsReadAccessToken
@@ -55,17 +55,18 @@ namespace UnitTest.Rollbar.Deploys
             return deployments;
         }
 
+        [Ignore]
         [TestMethod]
         public void TestRollbarDeploysManager()
         {
             var initialDeployments = this.GetAllDeployments();
 
             var deployment = DeploymentFactory.CreateDeployment(
-                    environment: RollbarUnitTestSettings.Environment, 
-                    revision: "99909a3a5a3dd4363f414161f340b582bb2e4161", 
+                    environment: RollbarUnitTestSettings.Environment,
+                    revision: "99909a3a5a3dd4363f414161f340b582bb2e4161",
                     comment: "Some new unit test deployment @ " + DateTimeOffset.Now,
-                    localUserName: "UnitTestRunner", 
-                    rollbarUserName: "rollbar" 
+                    localUserName: "UnitTestRunner",
+                    rollbarUserName: "rollbar"
                     );
 
             var task = this._deploysManager.RegisterAsync(deployment);

--- a/UnitTest.Rollbar.NetPlatformExtensions/RollbarLoggerFixture.cs
+++ b/UnitTest.Rollbar.NetPlatformExtensions/RollbarLoggerFixture.cs
@@ -31,6 +31,7 @@ namespace UnitTest.Rollbar.NetPlatformExtensions
         }
 
 
+        [Ignore]
         [TestMethod]
         public void TestBasics()
         {

--- a/UnitTest.Rollbar.PlugIns.Log4net/RollbarAppenderFixture.cs
+++ b/UnitTest.Rollbar.PlugIns.Log4net/RollbarAppenderFixture.cs
@@ -29,7 +29,7 @@ namespace UnitTest.Rollbar.PlugIns.Log4net
         /// The rollbar comm error events
         /// </summary>
         private readonly List<CommunicationErrorEventArgs> _rollbarCommErrorEvents = new List<CommunicationErrorEventArgs>();
-        
+
         /// <summary>
         /// Setups the fixture.
         /// </summary>
@@ -82,6 +82,7 @@ namespace UnitTest.Rollbar.PlugIns.Log4net
         /// <summary>
         /// Defines the test method TestAppenderReconfiguration.
         /// </summary>
+        [Ignore]
         [TestMethod]
         public void TestAppenderReconfiguration()
         {
@@ -93,18 +94,18 @@ namespace UnitTest.Rollbar.PlugIns.Log4net
             };
 
             RollbarAppender appender = new RollbarAppender(
-                RollbarUnitTestSettings.AccessToken, 
-                RollbarUnitTestSettings.Environment, 
+                RollbarUnitTestSettings.AccessToken,
+                RollbarUnitTestSettings.Environment,
                 TimeSpan.FromSeconds(3)
                 );
 
             string repositoryName = typeof(RollbarAppenderFixture).Name;
             var repository = LoggerManager.CreateRepository(repositoryName);
-            string loggerName = typeof(RollbarAppenderFixture).Name; 
+            string loggerName = typeof(RollbarAppenderFixture).Name;
             BasicConfigurator.Configure(repository, appender);
             ILog log = LogManager.GetLogger(repositoryName, loggerName);
 
-         
+
             log.Info("Via log4net");
 
             RollbarLoggerConfig newConfig = new RollbarLoggerConfig();

--- a/UnitTest.Rollbar.PlugIns.MSEnterpriseLibrary/RollbarExceptionHandlerFixture.cs
+++ b/UnitTest.Rollbar.PlugIns.MSEnterpriseLibrary/RollbarExceptionHandlerFixture.cs
@@ -38,25 +38,26 @@ namespace UnitTest.Rollbar.PlugIns.MSEnterpriseLibrary
 
         }
 
+        [Ignore]
         [TestMethod]
         public void TestBasics()
         {
             _rollbarCommunicationEventsCount = 0;
-            
+
             IExceptionHandler exceptionHandler = null;
             const int totalExceptionStackFrames = 10;
             int expectedCount = 0;
 
             exceptionHandler = new RollbarExceptionHandler(RollbarUnitTestSettings.AccessToken, RollbarUnitTestSettings.Environment, null);
             exceptionHandler.HandleException(
-                ExceptionSimulator.GetExceptionWith(totalExceptionStackFrames, "RollbarExceptionHandlerFixture: TestBasics non-blocking..."), 
+                ExceptionSimulator.GetExceptionWith(totalExceptionStackFrames, "RollbarExceptionHandlerFixture: TestBasics non-blocking..."),
                 Guid.NewGuid()
                 );
             expectedCount++;
 
             exceptionHandler = new RollbarExceptionHandler(RollbarUnitTestSettings.AccessToken, RollbarUnitTestSettings.Environment, TimeSpan.FromSeconds(5));
             exceptionHandler.HandleException(
-                ExceptionSimulator.GetExceptionWith(totalExceptionStackFrames,"RollbarExceptionHandlerFixture: TestBasics blocking..."), 
+                ExceptionSimulator.GetExceptionWith(totalExceptionStackFrames,"RollbarExceptionHandlerFixture: TestBasics blocking..."),
                 Guid.NewGuid()
                 );
             expectedCount++;

--- a/UnitTest.Rollbar/PayloadTruncation/PayloadTruncationFixture.cs
+++ b/UnitTest.Rollbar/PayloadTruncation/PayloadTruncationFixture.cs
@@ -36,6 +36,7 @@ namespace UnitTest.Rollbar.PayloadTruncation
         {
         }
 
+        [Ignore]
         [TestMethod]
         public void TestTruncation()
         {
@@ -48,7 +49,7 @@ namespace UnitTest.Rollbar.PayloadTruncation
                     new Dictionary<string, object>() {{"longDataString", "long-string-very-long-string-very-long-" }, {"theDataNumber", 15 }, })
                     ),
                 new Payload(this._config.RollbarLoggerConfig.RollbarDestinationOptions.AccessToken, new Data(
-                    this._config.RollbarLoggerConfig, 
+                    this._config.RollbarLoggerConfig,
                     new Body("A terrible crash!"),
                     new Dictionary<string, object>() {{"longDataString", "long-string-very-long-string-very-long-" }, {"theDataNumber", 15 }, })
                     ),

--- a/UnitTest.Rollbar/RollbarClientFixture.cs
+++ b/UnitTest.Rollbar/RollbarClientFixture.cs
@@ -29,11 +29,12 @@ namespace UnitTest.Rollbar
 
         private static MessagePackage CrateTestPackage()
         {
-            MessagePackage package = 
+            MessagePackage package =
                 new MessagePackage($"{nameof(RollbarClientFixture)}.BasicTest");
             return package;
         }
 
+        [Ignore]
         [TestMethod]
         public void TestUsingDefaultConfig()
         {
@@ -63,7 +64,7 @@ namespace UnitTest.Rollbar
             // [EXPECT]: even under all the good networking conditions sending a payload should not succeed
             RollbarInfrastructureOptions infrastructureOptions =
                 new RollbarInfrastructureOptions();
-            infrastructureOptions.PayloadPostTimeout = 
+            infrastructureOptions.PayloadPostTimeout =
                 TimeSpan.FromMilliseconds(5); // short enough
             RollbarInfrastructure.Instance.Config.RollbarInfrastructureOptions
                 .Reconfigure(infrastructureOptions);
@@ -84,6 +85,7 @@ namespace UnitTest.Rollbar
             }
         }
 
+        [Ignore]
         [TestMethod]
         public void TestUsingLongEnoughTimeout()
         {
@@ -92,7 +94,7 @@ namespace UnitTest.Rollbar
             // [EXPECT]: even under all the good networking conditions sending a payload should succeed
             RollbarInfrastructureOptions infrastructureOptions =
                 new RollbarInfrastructureOptions();
-            infrastructureOptions.PayloadPostTimeout = 
+            infrastructureOptions.PayloadPostTimeout =
                 TimeSpan.FromMilliseconds(2000); // long enough
             RollbarInfrastructure.Instance.Config.RollbarInfrastructureOptions
                 .Reconfigure(infrastructureOptions);

--- a/UnitTest.Rollbar/RollbarLoggerBlockingWrapperFixture.cs
+++ b/UnitTest.Rollbar/RollbarLoggerBlockingWrapperFixture.cs
@@ -61,6 +61,7 @@ namespace UnitTest.Rollbar
         }
 
 
+        [Ignore]
         [TestMethod]
         public void HasBlockingBehavior()
         {
@@ -139,6 +140,7 @@ namespace UnitTest.Rollbar
             }
         }
 
+        [Ignore]
         [DataTestMethod]
         [DataRow(ErrorLevel.Critical)]
         [DataRow(ErrorLevel.Error)]
@@ -153,12 +155,12 @@ namespace UnitTest.Rollbar
                 acctualLogLevel = payload.Data.Level.Value;
             }
 
-            RollbarDestinationOptions destinationOptions = 
+            RollbarDestinationOptions destinationOptions =
                 new RollbarDestinationOptions(
-                    RollbarUnitTestSettings.AccessToken, 
+                    RollbarUnitTestSettings.AccessToken,
                     RollbarUnitTestSettings.Environment
                     );
-            RollbarPayloadManipulationOptions payloadManipulationOptions = 
+            RollbarPayloadManipulationOptions payloadManipulationOptions =
                 new RollbarPayloadManipulationOptions(Transform);
             var loggerConfig = new RollbarLoggerConfig();
             loggerConfig.RollbarDestinationOptions.Reconfigure(destinationOptions);

--- a/UnitTest.Rollbar/RollbarLoggerFixture.cs
+++ b/UnitTest.Rollbar/RollbarLoggerFixture.cs
@@ -60,6 +60,7 @@ namespace UnitTest.Rollbar
             //TODO:
         }
 
+        [Ignore]
         [TestMethod]
         public void RethrowConfigOptionWorks()
         {
@@ -110,6 +111,7 @@ namespace UnitTest.Rollbar
             Assert.AreEqual(2,rethrowCount,"matching total of rethrows...");
         }
 
+        [Ignore]
         [TestMethod]
         public void TransmitConfigOptionWorks()
         {
@@ -142,6 +144,7 @@ namespace UnitTest.Rollbar
         /// <summary>
         /// Defines the test method FaultyPayloadTransformationTest.
         /// </summary>
+        [Ignore]
         [TestMethod]
         public void FaultyPayloadTransformationTest()
         {
@@ -172,6 +175,7 @@ namespace UnitTest.Rollbar
         /// <summary>
         /// Defines the test method FaultyCheckIgnoreTest.
         /// </summary>
+        [Ignore]
         [TestMethod]
         public void FaultyCheckIgnoreTest()
         {
@@ -202,6 +206,7 @@ namespace UnitTest.Rollbar
         /// <summary>
         /// Defines the test method FaultyTruncateTest.
         /// </summary>
+        [Ignore]
         [TestMethod]
         public void FaultyTruncateTest()
         {
@@ -256,6 +261,7 @@ namespace UnitTest.Rollbar
         /// Trickies the package test.
         /// </summary>
         /// <param name="trickyPackage">The tricky package.</param>
+        [Ignore]
         [DataTestMethod]
         [DataRow(TrickyPackage.AsyncFaultyPackage)]
         [DataRow(TrickyPackage.SyncFaultyPackage)]
@@ -305,6 +311,7 @@ namespace UnitTest.Rollbar
         /// <summary>
         /// Defines the test method RateLimitConfigSettingOverridesServerHeadersBasedReportingRateTest.
         /// </summary>
+        [Ignore]
         [TestMethod]
         public void RateLimitConfigSettingOverridesServerHeadersBasedReportingRateTest()
         {
@@ -465,7 +472,7 @@ namespace UnitTest.Rollbar
         //            errorCount++;
         //        }
         //        Assert.AreEqual(0, errorCount, "Checking errorCount 3.");
-        //        //TODO: gain access to the payload store persisted records count. 
+        //        //TODO: gain access to the payload store persisted records count.
         //        //      The count is expected to be 1.
 
         //        newConfig.ProxyAddress = null;
@@ -486,7 +493,7 @@ namespace UnitTest.Rollbar
         //            errorCount++;
         //        }
         //        Assert.AreEqual(0, errorCount, "Checking errorCount 4.");
-        //        //TODO: gain access to the payload store persisted records count. 
+        //        //TODO: gain access to the payload store persisted records count.
         //        //      The count is expected to be 1 (one record stuck with wrfng proxy settings until stale in a few days).
         //    }
         //}
@@ -509,6 +516,7 @@ namespace UnitTest.Rollbar
         /// <summary>
         /// Defines the test method ScopedInstanceTest.
         /// </summary>
+        [Ignore]
         [TestMethod]
         [Timeout(maxScopedInstanceTestDurationInMillisec)]
         public void ScopedInstanceTest()
@@ -516,7 +524,7 @@ namespace UnitTest.Rollbar
             // we need to make sure we are starting clean:
             RollbarQueueController.Instance.FlushQueues();
             RollbarQueueController.Instance.Start();
-            var accessTokenQueues = 
+            var accessTokenQueues =
                 RollbarQueueController.Instance.GetQueues(RollbarUnitTestSettings.AccessToken);
             while (accessTokenQueues.Any())
             {
@@ -539,13 +547,13 @@ namespace UnitTest.Rollbar
                     }
                 }
                 Thread.Sleep(TimeSpan.FromMilliseconds(250));
-                accessTokenQueues = 
+                accessTokenQueues =
                     RollbarQueueController.Instance.GetQueues(RollbarUnitTestSettings.AccessToken);
             }
 
-            RollbarDestinationOptions destinationOptions = 
+            RollbarDestinationOptions destinationOptions =
                 new RollbarDestinationOptions(
-                    RollbarUnitTestSettings.AccessToken, 
+                    RollbarUnitTestSettings.AccessToken,
                     RollbarUnitTestSettings.Environment
                     );
             RollbarLoggerConfig loggerConfig = new RollbarLoggerConfig();
@@ -558,16 +566,16 @@ namespace UnitTest.Rollbar
                 this.IncrementCount<CommunicationEventArgs>();
                 logger.Log(ErrorLevel.Error, "test message");
             }
-            // an unused queue does not get removed immediately (but eventually) - so let's wait for it for a few processing cycles: 
-            int currentQueuesCount = 
+            // an unused queue does not get removed immediately (but eventually) - so let's wait for it for a few processing cycles:
+            int currentQueuesCount =
                 RollbarQueueController.Instance.GetQueuesCount(RollbarUnitTestSettings.AccessToken);
             while (totalInitialQueues != currentQueuesCount)
             {
                 string msg = "Current queues count: " + currentQueuesCount + " while initial count was: " + totalInitialQueues;
                 System.Diagnostics.Trace.WriteLine(msg);
                 Console.WriteLine(msg);
-                Thread.Sleep(TimeSpan.FromMilliseconds(250)); 
-                currentQueuesCount = 
+                Thread.Sleep(TimeSpan.FromMilliseconds(250));
+                currentQueuesCount =
                     RollbarQueueController.Instance.GetQueuesCount(RollbarUnitTestSettings.AccessToken);
             }
 
@@ -579,6 +587,7 @@ namespace UnitTest.Rollbar
         /// <summary>
         /// Defines the test method ReportException.
         /// </summary>
+        [Ignore]
         [TestMethod]
         public void ReportException()
         {
@@ -597,6 +606,7 @@ namespace UnitTest.Rollbar
         /// <summary>
         /// Defines the test method ReportFromCatch.
         /// </summary>
+        [Ignore]
         [TestMethod]
         public void ReportFromCatch()
         {
@@ -624,6 +634,7 @@ namespace UnitTest.Rollbar
         /// <summary>
         /// Defines the test method ReportMessage.
         /// </summary>
+        [Ignore]
         [TestMethod]
         public void ReportMessage()
         {
@@ -644,6 +655,7 @@ namespace UnitTest.Rollbar
         /// Conveniences the methods use appropriate error levels.
         /// </summary>
         /// <param name="expectedLogLevel">The expected log level.</param>
+        [Ignore]
         [DataTestMethod]
         [DataRow(ErrorLevel.Critical)]
         [DataRow(ErrorLevel.Error)]
@@ -711,6 +723,7 @@ namespace UnitTest.Rollbar
         /// <summary>
         /// Defines the test method LongReportIsAsync.
         /// </summary>
+        [Ignore]
         [TestMethod]
         public void LongReportIsAsync()
         {
@@ -751,6 +764,7 @@ namespace UnitTest.Rollbar
         /// <summary>
         /// Defines the test method ExceptionWhileTransformingPayloadAsync.
         /// </summary>
+        [Ignore]
         [TestMethod]
         [Timeout(5000)]
         public void ExceptionWhileTransformingPayloadAsync()
@@ -818,6 +832,7 @@ namespace UnitTest.Rollbar
         /// <summary>
         /// Defines the test method MultithreadedStressTest_BlockingLogs.
         /// </summary>
+        [Ignore]
         [TestMethod]
         [Timeout(120000)]
         public void MultithreadedStressTest_BlockingLogs()
@@ -872,6 +887,7 @@ namespace UnitTest.Rollbar
         /// <summary>
         /// Defines the test method MultithreadedStressTest.
         /// </summary>
+        [Ignore]
         [TestMethod]
         [Timeout(100000)]
         public void MultithreadedStressTest()
@@ -894,7 +910,7 @@ namespace UnitTest.Rollbar
 
             this.IncrementCount<CommunicationEventArgs>(RollbarInfrastructure.Instance.Config.RollbarInfrastructureOptions.ReportingQueueDepth);
 
-            List<IRollbar> rollbars = 
+            List<IRollbar> rollbars =
                 new List<IRollbar>(MultithreadedStressTestParams.TotalThreads);
             for (int i = 0; i < MultithreadedStressTestParams.TotalThreads; i++)
             {
@@ -927,7 +943,7 @@ namespace UnitTest.Rollbar
                 var task = new Task((state) =>
                 {
                     int taskIndex = (int)state;
-                    TimeSpan sleepIntervalDelta = 
+                    TimeSpan sleepIntervalDelta =
                         TimeSpan.FromTicks(taskIndex * MultithreadedStressTestParams.LogIntervalDelta.Ticks);
                     var logger = loggers[taskIndex];
                     int i = 0;
@@ -960,7 +976,7 @@ namespace UnitTest.Rollbar
 
             Task.WaitAll(tasks.ToArray());
 
-            int expectedCount = 
+            int expectedCount =
                 MultithreadedStressTestParams.TotalThreads * MultithreadedStressTestParams.LogsPerThread;
 
             //we need this delay loop for async logs:
@@ -970,7 +986,7 @@ namespace UnitTest.Rollbar
             }
 
             Thread.Sleep(TimeSpan.FromSeconds(10));
-            
+
             RollbarQueueController.Instance.InternalEvent -= RollbarStress_InternalEvent;
 
             Assert.AreEqual(expectedCount, RollbarLoggerFixture.stressLogsCount, "Matching stressLogsCount");

--- a/UnitTest.RollbarTestCommon/RollbarLiveFixtureBase.cs
+++ b/UnitTest.RollbarTestCommon/RollbarLiveFixtureBase.cs
@@ -100,7 +100,7 @@ namespace UnitTest.Rollbar
         /// <param name="e">The <see cref="RollbarEventArgs"/> instance containing the event data.</param>
         private void OnRollbarInternalEvent(object sender, RollbarEventArgs e)
         {
-            if(!(e is CommunicationEventArgs)) 
+            if(!(e is CommunicationEventArgs))
             {
             }
 
@@ -196,7 +196,7 @@ namespace UnitTest.Rollbar
             else
             {
                 this._rollbarEventsByType.Add(
-                    eventType, 
+                    eventType,
                     new List<RollbarEventArgs>(new[] {rollbarEvent})
                     );
             }
@@ -253,7 +253,7 @@ namespace UnitTest.Rollbar
         /// Clears this instance.
         /// </summary>
         /// <typeparam name="TRollbarEvent">The type of the t rollbar event.</typeparam>
-        protected void Clear<TRollbarEvent>() 
+        protected void Clear<TRollbarEvent>()
             where TRollbarEvent : RollbarEventArgs
         {
             if (this._rollbarEventsByType.TryGetValue(typeof(TRollbarEvent), out var rollbarEvents))
@@ -350,7 +350,7 @@ namespace UnitTest.Rollbar
         {
             if (this._loggerConfig == null)
             {
-                RollbarDestinationOptions destinationOptions = 
+                RollbarDestinationOptions destinationOptions =
                     new RollbarDestinationOptions(rollbarAccessToken, rollbarEnvironment);
 
                 RollbarDataSecurityOptions dataSecurityOptions = new RollbarDataSecurityOptions();
@@ -404,14 +404,15 @@ namespace UnitTest.Rollbar
             Assert.AreEqual(this.GetCount<CommunicationEventArgs>(), initialCommunicationEventsCount + 1, "Confirming Rollbar.NET is operational...");
         }
 
+        [Ignore]
         [TestMethod]
-        public void _VerifyInstanceOperationalTest() 
+        public void _VerifyInstanceOperationalTest()
         {
             // this test more about verifying if the test harness itself works well:
 
             this.ClearAllRollbarEvents();
 
-            using(IRollbar rollbar = this.ProvideDisposableRollbar()) 
+            using(IRollbar rollbar = this.ProvideDisposableRollbar())
             {
                 this.VerifyInstanceOperational(rollbar);
             }


### PR DESCRIPTION
## Description of the change

Temporarily disable tests preventing the CI build to complete.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)
- [SC-132805](https://app.shortcut.com/rollbar/story/132805/disable-certain-unit-tests-in-the-rollbar-net-repo)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
